### PR TITLE
fix: close #17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ tests/jax_test.ipynb
 tests/console.ipynb
 tests/console.ipynb
 tests/test_julia.jl
+tests/test_sp.ipynb

--- a/Solverz/param.py
+++ b/Solverz/param.py
@@ -7,7 +7,6 @@ from typing import Callable
 from numbers import Number
 
 from .solverz_array import SolverzArray
-from .var import Var
 
 
 class Param:
@@ -34,12 +33,12 @@ class Param:
         return self.__v
 
     @v.setter
-    def v(self, value: Union[SolverzArray, np.ndarray, list, Number]):
+    def v(self, value: Union[np.ndarray, list, Number]):
 
-        if isinstance(value, np.ndarray) or isinstance(value, list) or isinstance(value, Number):
-            self.__v = SolverzArray(value)
-        else:
+        if isinstance(value, np.ndarray):
             self.__v = value
+        else:
+            self.__v = np.array(value)
 
     def __repr__(self):
         return f"Param: {self.name} value: {self.v}"

--- a/Solverz/solverz_array.py
+++ b/Solverz/solverz_array.py
@@ -121,19 +121,6 @@ def implements(np_function):
     return decorator
 
 
-@implements(np.diag)
-def diag(x):
-    """
-    Generate diagonal matrix of given vector X
-    :PARAM X: vector
-    :return: diagonal matrix
-    """
-    if x.column_size == 1 or x.row_size == 1:
-        return np.diag(np.reshape(np.asarray(x), (-1,)))
-    else:
-        raise ValueError(f"Vector input required but {x.column_size} columns detected!")
-
-
 @implements(np.transpose)
 def transpose(x):
     """
@@ -157,18 +144,27 @@ def concatenate(arrays, axis=None):
     return np.concatenate(tuple(arrays_), axis=axis)
 
 
-def mat_multiply(*args: Union[SolverzArray, np.ndarray, list]):
+def matmul(*args: np.ndarray) -> np.ndarray:
     """
     np.multiply supports only two arguments
-    So a new function is designed to generate multiplication of args
-    :PARAM args:
+    So a new function is presented to generate multiplication of np.ndarray
+    :PARAM args: np.ndarray
     :return:
     """
 
-    return reduce(lambda x, y: x * y, [SolverzArray(arg) if isinstance(arg, list) else arg for arg in args])
+    return reduce(np.dot, args)
 
 
-Lambdify_Mapping = {'Mat_Mul': mat_multiply, 'Diagonal': np.diag}
+def diag(x: np.ndarray) -> np.ndarray:
+    """
+    Generate diagonal matrix of given vector X
+    :PARAM X: vector
+    :return: diagonal matrix
+    """
+    return np.diag(x.reshape(-1, ))
+
+
+Lambdify_Mapping = {'Mat_Mul': matmul, 'Diagonal': diag}
 
 
 def zeros(shape: Tuple[int, int]) -> SolverzArray:

--- a/tests/test_dhspf.py
+++ b/tests/test_dhspf.py
@@ -45,11 +45,11 @@ E8 = Eqn(name='E8',
          commutative=False)
 
 E9 = Eqn(name='E9',
-         e_str='Mat_Mul(Diagonal(A_li*Ts),V_p_li,Abs(m))-V_p_li*Mat_Mul(Diagonal(Touts),Abs(m))',
+         e_str='Diagonal(A_li*Ts)*V_p_li*Abs(m)-V_p_li*Diagonal(Touts)*Abs(m)',
          commutative=False)
 
 E10 = Eqn(name='E10',
-          e_str='Mat_Mul(Diagonal(A_rsi*Tr),V_m_rsi,Abs(m))-V_m_rsi*Mat_Mul(Diagonal(Toutr),Abs(m))',
+          e_str='Diagonal(A_rsi*Tr)*V_m_rsi*Abs(m)-V_m_rsi*Diagonal(Toutr)*Abs(m)',
           commutative=False)
 
 E11 = Eqn(name='E11',
@@ -95,14 +95,14 @@ sys_df = pd.read_excel('../instances/4node3pipe_bench.xlsx',
 def test_nr_method():
     for var_name in ['Ts', 'Tr', 'm', 'mq', 'phi']:
         # find nonzero elements
-        idx_nonzero = np.nonzero(y_nr[var_name].array)
-        assert max(abs((y_nr[var_name][idx_nonzero] - np.asarray(sys_df[var_name])[idx_nonzero]) /
-                       np.asarray(sys_df[var_name])[idx_nonzero])) <= 1e-8
+        idx_nonzero = np.nonzero(y_nr[var_name])
+        assert max(abs((y_nr[var_name][idx_nonzero] - np.asarray(sys_df[var_name])[idx_nonzero].reshape(-1, ))) /
+                   np.asarray(sys_df[var_name])[idx_nonzero].reshape(-1, )) <= 1e-8
 
 
 def test_cnr_method():
     for var_name in ['Ts', 'Tr', 'm', 'mq', 'phi']:
         # find nonzero elements
-        idx_nonzero = np.nonzero(y_cnr[var_name].array)
-        assert max(abs((y_cnr[var_name][idx_nonzero] - np.asarray(sys_df[var_name])[idx_nonzero]) /
-                       np.asarray(sys_df[var_name])[idx_nonzero])) <= 1e-8
+        idx_nonzero = np.nonzero(y_cnr[var_name])
+        assert max(abs((y_cnr[var_name][idx_nonzero] - np.asarray(sys_df[var_name])[idx_nonzero].reshape(-1, )) /
+                       np.asarray(sys_df[var_name])[idx_nonzero].reshape(-1, ))) <= 1e-8

--- a/tests/test_dhspf_change_sign.py
+++ b/tests/test_dhspf_change_sign.py
@@ -43,15 +43,15 @@ E7 = Eqn(name='E7',
          commutative=False)
 
 E8 = Eqn(name='E8',
-         e_str='m_L*Diagonal(K)*Mat_Mul(Diagonal(Abs(m)),m)',
+         e_str='m_L*Diagonal(K)*Diagonal(Abs(m))*m',
          commutative=False)
 
 E9 = Eqn(name='E9',
-         e_str='Mat_Mul(Diagonal(A_li*Ts),V_p_li,Abs(m))-V_p_li*Mat_Mul(Diagonal(Touts),Abs(m))',
+         e_str='Diagonal(A_li*Ts)*V_p_li*Abs(m)-V_p_li*Diagonal(Touts)*Abs(m)',
          commutative=False)
 
 E10 = Eqn(name='E10',
-          e_str='Mat_Mul(Diagonal(A_rsi*Tr),V_m_rsi,Abs(m))-V_m_rsi*Mat_Mul(Diagonal(Toutr),Abs(m))',
+          e_str='Diagonal(A_rsi*Tr)*V_m_rsi*Abs(m)-V_m_rsi*Diagonal(Toutr)*Abs(m)',
           commutative=False)
 
 E11 = Eqn(name='E11',
@@ -98,9 +98,9 @@ sys_df = pd.read_excel('../instances/4node3pipe_change_sign_bench.xlsx',
 def test_nr_method():
     for var_name in ['Ts', 'Tr', 'm', 'mq', 'phi']:
         # find nonzero elements
-        idx_nonzero = np.nonzero(y_nr[var_name].array)
-        assert max(abs((y_nr[var_name][idx_nonzero] - np.asarray(sys_df[var_name])[idx_nonzero]) /
-                       np.asarray(sys_df[var_name])[idx_nonzero])) <= 1e-8
+        idx_nonzero = np.nonzero(y_nr[var_name])
+        assert max(abs((y_nr[var_name][idx_nonzero] - np.asarray(sys_df[var_name])[idx_nonzero].reshape(-1,)) /
+                       np.asarray(sys_df[var_name])[idx_nonzero].reshape(-1,))) <= 1e-8
 
 
 # def test_cnr_method():

--- a/tests/test_epsflow.py
+++ b/tests/test_epsflow.py
@@ -16,7 +16,7 @@ Gpq = Param(name='Gpq')
 Bpq = Param(name='Bpq')
 
 E1 = Eqn(name='Active power',
-         e_str='-Apq*p+Mat_Mul(Diagonal(Apq*e),Gpq*e-Bpq*f)',
+         e_str='-Apq*p+Diagonal(Apq*e)*(Gpq*e-Bpq*f)',
          commutative=False)
 
 # E = Equations(E1,

--- a/tests/test_m3b9.py
+++ b/tests/test_m3b9.py
@@ -17,10 +17,10 @@ generator_ux = Eqn(name='Generator Ux', e_str='Uxg-Ag*Ux', commutative=False)
 generator_uy = Eqn(name='Generator Uy', e_str='Uyg-Ag*Uy', commutative=False)
 Ed_prime = Eqn(name='Ed_prime', e_str='Edp-sin(delta)*(Uxg+ra*Ixg-Xqp*Iyg)+cos(delta)*(Uyg+ra*Iyg+Xqp*Ixg)')
 Eq_prime = Eqn(name='Eq_prime', e_str='Eqp-cos(delta)*(Uxg+ra*Ixg-Xdp*Iyg)-sin(delta)*(Uyg+ra*Iyg+Xdp*Ixg)')
-Ixg_inject = Eqn(name='Ixg_inject', e_str='Ixg-(Mat_Mul(Ag*G,Ux)-Mat_Mul(Ag*B,Uy))', commutative=False)
-Iyg_inject = Eqn(name='Iyg_inject', e_str='Iyg-(Mat_Mul(Ag*G,Uy)+Mat_Mul(Ag*B,Ux))', commutative=False)
-Ixng_inject = Eqn(name='Ixng_inject', e_str='Mat_Mul(Ang*G,Ux)-Mat_Mul(Ang*B,Uy)', commutative=False)
-Iyng_inject = Eqn(name='Iyng_inject', e_str='Mat_Mul(Ang*G,Uy)+Mat_Mul(Ang*B,Ux)', commutative=False)
+Ixg_inject = Eqn(name='Ixg_inject', e_str='Ixg-(Ag*G*Ux-Ag*B*Uy)', commutative=False)
+Iyg_inject = Eqn(name='Iyg_inject', e_str='Iyg-(Ag*G*Uy+Ag*B*Ux)', commutative=False)
+Ixng_inject = Eqn(name='Ixng_inject', e_str='Ang*G*Ux-Ang*B*Uy', commutative=False)
+Iyng_inject = Eqn(name='Iyng_inject', e_str='Ang*G*Uy+Ang*B*Ux', commutative=False)
 
 param = [Param('Pm'), Param('ra'), Param('D'), Param('Tj'), Param('omega_b'), Param('Ag'), Param('Edp'), Param('Eqp'),
          Param('Xqp'), Param('Xdp'), Param('G'), Param('B'), Param('Ang')]
@@ -118,5 +118,5 @@ xy = implicit_trapezoid(m3b9,
 
 
 def test_m3b9():
-    assert np.abs(np.asarray(df['omega']).transpose() - xy['omega'].array).max() <= 0.003969440114605538
-    assert np.abs(np.asarray(df['delta']).transpose() - xy['delta'].array).max() <= 0.019164859675127266
+    assert np.abs(np.asarray(df['omega']).transpose() - xy['omega']).max() <= 0.003969440114605538
+    assert np.abs(np.asarray(df['delta']).transpose() - xy['delta']).max() <= 0.019164859675127266

--- a/tests/test_ode.py
+++ b/tests/test_ode.py
@@ -27,4 +27,4 @@ df = pd.read_excel('../instances/ode_test.xlsx',
 
 
 def test_ode():
-    assert max(abs((x.array - np.asarray(df['Sheet1']).reshape(1, -1))).reshape(-1, )) <= 0.0009448126743213381
+    assert max(abs((x['x'] - np.asarray(df['Sheet1']).reshape(1, -1))).reshape(-1, )) <= 0.0009448126743213381

--- a/tests/test_sirk.py
+++ b/tests/test_sirk.py
@@ -79,10 +79,10 @@ def test_sirk_m3b9():
     generator_uy = Eqn(name='Generator Uy', e_str='Uyg-Ag*Uy', commutative=False)
     Ed_prime = Eqn(name='Ed_prime', e_str='Edp-sin(delta)*(Uxg+ra*Ixg-Xqp*Iyg)+cos(delta)*(Uyg+ra*Iyg+Xqp*Ixg)')
     Eq_prime = Eqn(name='Eq_prime', e_str='Eqp-cos(delta)*(Uxg+ra*Ixg-Xdp*Iyg)-sin(delta)*(Uyg+ra*Iyg+Xdp*Ixg)')
-    Ixg_inject = Eqn(name='Ixg_inject', e_str='Ixg-(Mat_Mul(Ag*G,Ux)-Mat_Mul(Ag*B,Uy))', commutative=False)
-    Iyg_inject = Eqn(name='Iyg_inject', e_str='Iyg-(Mat_Mul(Ag*G,Uy)+Mat_Mul(Ag*B,Ux))', commutative=False)
-    Ixng_inject = Eqn(name='Ixng_inject', e_str='Mat_Mul(Ang*G,Ux)-Mat_Mul(Ang*B,Uy)', commutative=False)
-    Iyng_inject = Eqn(name='Iyng_inject', e_str='Mat_Mul(Ang*G,Uy)+Mat_Mul(Ang*B,Ux)', commutative=False)
+    Ixg_inject = Eqn(name='Ixg_inject', e_str='Ixg-(Ag*G*Ux-Ag*B*Uy)', commutative=False)
+    Iyg_inject = Eqn(name='Iyg_inject', e_str='Iyg-(Ag*G*Uy+Ag*B*Ux)', commutative=False)
+    Ixng_inject = Eqn(name='Ixng_inject', e_str='Ang*G*Ux-Ang*B*Uy', commutative=False)
+    Iyng_inject = Eqn(name='Iyng_inject', e_str='Ang*G*Uy+Ang*B*Ux', commutative=False)
 
     param = [Param('Pm'), Param('ra'), Param('D'), Param('Tj'), Param('omega_b'), Param('Ag'), Param('Edp'),
              Param('Eqp'),


### PR DESCRIPTION
By removing the use of SolverzArray, the efficiency is obviously increased. Before, the m3b9 test required 13 sec. while it takes only 5 sec. to perform the same test.