### PR TITLE
0.8.1 hotfix: Mat_Mul correctness + csc_matvec fast path + time-varying sparse ban

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ Solverz/share
 /Solverz.egg-info
 Solverz/_version.py
 /.venv
+/review_notes/

--- a/Solverz/code_printer/python/module/module_generator.py
+++ b/Solverz/code_printer/python/module/module_generator.py
@@ -17,29 +17,31 @@ from Solverz.variable.variables import Vars, combine_Vars
 from Solverz.equation.hvp import Hvp
 
 
-def _has_sparse_in_param_list(PARAM, include_sparse_in_list: bool) -> bool:
+def _has_sparse_in_param_list(PARAM) -> bool:
     """Return True iff ``print_param`` would emit any sparse parameter
     into the ``param_list`` (the list that's forwarded as arguments to
-    ``inner_F`` / ``inner_J``).
+    ``inner_F`` / ``inner_J``) *in this module's code path*.
 
-    This mirrors the branching inside ``print_param`` so the JIT
-    decision stays synchronized with what actually appears in the
-    generated function signature.
+    With the Mat_Mul precompute architecture, ``print_F`` / ``print_J``
+    call ``print_param`` with ``include_sparse_in_list=False``, so
+    plain sparse ``dim=2`` params never enter ``param_list``. They
+    still get loaded inside the ``F_`` / ``J_`` wrappers, where scipy
+    is available, and only the precomputed dense vectors cross the
+    boundary into the inner functions.
 
-    A parameter enters ``param_list`` as a sparse object when:
+    That still leaves two branches in ``print_param`` that unconditionally
+    append to ``param_list`` regardless of the flag — and if any
+    parameter hits either branch the receiving ``inner_F`` / ``inner_J``
+    cannot be decorated with ``@njit`` (Numba rejects scipy.sparse
+    arguments at compile time):
 
-    - it is a ``TimeSeriesParam`` that is also sparse — the time-series
-      branch always appends to ``param_list`` regardless of
-      ``include_sparse_in_list``;
-    - it is ``triggerable=True`` AND sparse — the same
-      ``if not sparse or triggerable`` branch in ``print_param`` adds
-      it unconditionally;
-    - it is a plain sparse ``dim=2`` parameter AND the caller passed
-      ``include_sparse_in_list=True``.
+    - ``TimeSeriesParam`` with ``sparse=True`` — the time-series branch
+      always appends;
+    - ``triggerable=True`` with ``sparse=True`` — the ``if not sparse or
+      triggerable`` branch appends unconditionally.
 
-    If any such parameter exists, the receiving ``inner_F`` / ``inner_J``
-    cannot be decorated with ``@njit`` — Numba rejects scipy.sparse
-    arguments at compile time.
+    Pure element-wise models with no sparse params at all trivially
+    return False and continue to use ``@njit`` on everything.
     """
     for name, param in PARAM.items():
         if getattr(param, 'is_alias', False):
@@ -49,8 +51,6 @@ def _has_sparse_in_param_list(PARAM, include_sparse_in_list: bool) -> bool:
         if isinstance(param, TimeSeriesParam):
             return True
         if getattr(param, 'triggerable', False):
-            return True
-        if param.dim == 2 and include_sparse_in_list:
             return True
     return False
 
@@ -68,12 +68,13 @@ def render_modules(eqs: SymEquations,
     eqs.FormJac(y)
     p = parse_p(eqs.PARAM)
 
-    # Detect if any equation uses Mat_Mul (needs scipy.sparse pass-through).
-    # When Mat_Mul is present, the sparse matrix parameter (csc_array) must be
-    # loaded in the F_/J_ wrapper AND passed to inner functions. Since Numba's
-    # @njit cannot handle scipy.sparse objects, we selectively disable @njit
-    # for functions that receive or use sparse matrices.
-    has_mat_mul = any(eqn.mixed_matrix_vector for eqn in eqs.EQNs.values())
+    # The Mat_Mul precompute architecture unconditionally forces sparse
+    # matrix parameters OUT of the ``inner_F`` / ``inner_J`` argument
+    # lists (they are loaded in the F_ / J_ wrappers and only the
+    # precomputed dense vectors cross the boundary). See the docstring
+    # of ``_has_sparse_in_param_list`` below for the edge cases that
+    # still land sparse params in the inner list via ``TimeSeriesParam``
+    # or ``triggerable=True`` — those are what drive the @njit gating.
 
     code_dict = dict()
     # Extract Mat_Mul precompute info first; used by F, inner_F, and sub_inner_F.
@@ -86,42 +87,38 @@ def render_modules(eqs: SymEquations,
                              eqs.var_address,
                              eqs.PARAM,
                              eqs.nstep,
-                             include_sparse_in_list=has_mat_mul,
                              precompute_info=precompute_info_F)
     code_dict["inner_F"] = print_inner_F(eqs.EQNs,
                                          eqs.a,
                                          eqs.var_address,
                                          eqs.PARAM,
                                          eqs.nstep,
-                                         include_sparse_in_list=has_mat_mul,
                                          precompute_info=precompute_info_F)
 
     J = print_inner_J(eqs.var_address,
                       eqs.PARAM,
                       eqs.jac,
-                      eqs.nstep,
-                      include_sparse_in_list=has_mat_mul)
+                      eqs.nstep)
     code_dict["J"] = print_J(eqs.__class__.__name__,
                              eqs.eqn_size,
                              eqs.var_address,
                              eqs.PARAM,
                              eqs.jac.shape,
                              eqs.nstep,
-                             include_sparse_in_list=has_mat_mul,
                              mutable_matrix_blocks=J.get('mutable_matrix_blocks'))
     code_dict["inner_J"] = J['code_inner_J']
     code_dict["sub_inner_J"] = J['code_sub_inner_J']
     if J.get('no_njit_sub_inner_J'):
         code_dict["no_njit_sub_inner_J"] = J['no_njit_sub_inner_J']
     # @njit decision for inner_F / inner_J is based on what actually
-    # lands in the function's argument list. Even with the Mat_Mul
-    # precompute architecture (``include_sparse_in_list=False``), sparse
-    # matrices can still enter ``param_list`` via the TimeSeriesParam or
-    # ``triggerable=True`` branches of ``print_param``. If any such
-    # sparse parameter exists we must NOT wrap the inner function with
-    # ``@njit`` because Numba cannot digest scipy.sparse arguments.
-    sparse_in_inner_list = _has_sparse_in_param_list(
-        eqs.PARAM, include_sparse_in_list=False)
+    # lands in the function's argument list. Even though the Mat_Mul
+    # precompute architecture forces plain sparse ``dim=2`` matrices
+    # OUT of ``param_list``, sparse matrices can still enter via the
+    # ``TimeSeriesParam`` or ``triggerable=True`` branches of
+    # ``print_param``. If any such sparse parameter exists we must NOT
+    # wrap the inner function with ``@njit`` because Numba cannot
+    # digest scipy.sparse arguments.
+    sparse_in_inner_list = _has_sparse_in_param_list(eqs.PARAM)
     code_dict["no_njit_inner_F"] = sparse_in_inner_list
     code_dict["no_njit_inner_J"] = sparse_in_inner_list
     if sparse_in_inner_list:

--- a/Solverz/code_printer/python/module/module_generator.py
+++ b/Solverz/code_printer/python/module/module_generator.py
@@ -6,6 +6,7 @@ import re
 from typing import Dict
 
 from Solverz.equation.equations import AE as SymAE, FDAE as SymFDAE, DAE as SymDAE
+from Solverz.equation.param import TimeSeriesParam
 from Solverz.utilities.io import save
 from Solverz.code_printer.python.utilities import parse_p, parse_trigger_func
 from Solverz.code_printer.python.module.module_printer import print_F, print_inner_F, print_sub_inner_F, \
@@ -14,6 +15,44 @@ from Solverz.equation.equations import Equations as SymEquations
 from Solverz.num_api.module_parser import modules
 from Solverz.variable.variables import Vars, combine_Vars
 from Solverz.equation.hvp import Hvp
+
+
+def _has_sparse_in_param_list(PARAM, include_sparse_in_list: bool) -> bool:
+    """Return True iff ``print_param`` would emit any sparse parameter
+    into the ``param_list`` (the list that's forwarded as arguments to
+    ``inner_F`` / ``inner_J``).
+
+    This mirrors the branching inside ``print_param`` so the JIT
+    decision stays synchronized with what actually appears in the
+    generated function signature.
+
+    A parameter enters ``param_list`` as a sparse object when:
+
+    - it is a ``TimeSeriesParam`` that is also sparse — the time-series
+      branch always appends to ``param_list`` regardless of
+      ``include_sparse_in_list``;
+    - it is ``triggerable=True`` AND sparse — the same
+      ``if not sparse or triggerable`` branch in ``print_param`` adds
+      it unconditionally;
+    - it is a plain sparse ``dim=2`` parameter AND the caller passed
+      ``include_sparse_in_list=True``.
+
+    If any such parameter exists, the receiving ``inner_F`` / ``inner_J``
+    cannot be decorated with ``@njit`` — Numba rejects scipy.sparse
+    arguments at compile time.
+    """
+    for name, param in PARAM.items():
+        if getattr(param, 'is_alias', False):
+            continue
+        if not getattr(param, 'sparse', False):
+            continue
+        if isinstance(param, TimeSeriesParam):
+            return True
+        if getattr(param, 'triggerable', False):
+            return True
+        if param.dim == 2 and include_sparse_in_list:
+            return True
+    return False
 
 
 def render_modules(eqs: SymEquations,
@@ -37,35 +76,64 @@ def render_modules(eqs: SymEquations,
     has_mat_mul = any(eqn.mixed_matrix_vector for eqn in eqs.EQNs.values())
 
     code_dict = dict()
+    # Extract Mat_Mul precompute info first; used by F, inner_F, and sub_inner_F.
+    sub_inner_F_codes, precompute_info_F = print_sub_inner_F(eqs.EQNs)
+    code_dict["sub_inner_F"] = sub_inner_F_codes
+    # Precompute architecture: sub_inner_F no longer receives sparse matrices,
+    # so all sub-functions can now be @njit (empty no_njit set).
+    code_dict["no_njit_sub_inner_F"] = set()
     code_dict['F'] = print_F(eqs.__class__.__name__,
                              eqs.var_address,
                              eqs.PARAM,
                              eqs.nstep,
-                             include_sparse_in_list=has_mat_mul)
+                             include_sparse_in_list=has_mat_mul,
+                             precompute_info=precompute_info_F)
     code_dict["inner_F"] = print_inner_F(eqs.EQNs,
                                          eqs.a,
                                          eqs.var_address,
                                          eqs.PARAM,
                                          eqs.nstep,
-                                         include_sparse_in_list=has_mat_mul)
-    sub_inner_F_codes, no_njit_F = print_sub_inner_F(eqs.EQNs)
-    code_dict["sub_inner_F"] = sub_inner_F_codes
-    code_dict["no_njit_sub_inner_F"] = no_njit_F
+                                         include_sparse_in_list=has_mat_mul,
+                                         precompute_info=precompute_info_F)
 
+    J = print_inner_J(eqs.var_address,
+                      eqs.PARAM,
+                      eqs.jac,
+                      eqs.nstep,
+                      include_sparse_in_list=has_mat_mul)
     code_dict["J"] = print_J(eqs.__class__.__name__,
                              eqs.eqn_size,
                              eqs.var_address,
                              eqs.PARAM,
                              eqs.jac.shape,
                              eqs.nstep,
-                             include_sparse_in_list=has_mat_mul)
-    J = print_inner_J(eqs.var_address,
-                      eqs.PARAM,
-                      eqs.jac,
-                      eqs.nstep,
-                      include_sparse_in_list=has_mat_mul)
+                             include_sparse_in_list=has_mat_mul,
+                             mutable_matrix_blocks=J.get('mutable_matrix_blocks'))
     code_dict["inner_J"] = J['code_inner_J']
     code_dict["sub_inner_J"] = J['code_sub_inner_J']
+    if J.get('no_njit_sub_inner_J'):
+        code_dict["no_njit_sub_inner_J"] = J['no_njit_sub_inner_J']
+    # @njit decision for inner_F / inner_J is based on what actually
+    # lands in the function's argument list. Even with the Mat_Mul
+    # precompute architecture (``include_sparse_in_list=False``), sparse
+    # matrices can still enter ``param_list`` via the TimeSeriesParam or
+    # ``triggerable=True`` branches of ``print_param``. If any such
+    # sparse parameter exists we must NOT wrap the inner function with
+    # ``@njit`` because Numba cannot digest scipy.sparse arguments.
+    sparse_in_inner_list = _has_sparse_in_param_list(
+        eqs.PARAM, include_sparse_in_list=False)
+    code_dict["no_njit_inner_F"] = sparse_in_inner_list
+    code_dict["no_njit_inner_J"] = sparse_in_inner_list
+    if sparse_in_inner_list:
+        # Sub-functions inherit whatever inner_F / inner_J forward to
+        # them, so they are also unsafe to @njit in this case.
+        no_njit_F_set = code_dict.get("no_njit_sub_inner_F") or set()
+        code_dict["no_njit_sub_inner_F"] = no_njit_F_set | {
+            i for i in range(len(code_dict["sub_inner_F"]))}
+    # Mutable matrix block functions — dedicated @njit scatter-add loops.
+    code_dict["mut_mat_block_funcs"] = J.get('mut_mat_block_funcs', [])
+    mut_mat_mappings = J.get('mut_mat_mappings', {})
+    code_dict["mut_mat_mapping_keys"] = sorted(mut_mat_mappings.keys())
 
     if make_hvp:
         eqs.hvp = Hvp(eqs.jac)
@@ -111,6 +179,10 @@ def render_modules(eqs: SymEquations,
 
     row, col, data = eqs.jac.parse_row_col_data()
     eqn_parameter.update({'row': row, 'col': col, 'data': data})
+    # Store mutable matrix block mapping arrays (loaded from setting at
+    # runtime, passed to the block @njit functions).
+    if mut_mat_mappings:
+        eqn_parameter.update(mut_mat_mappings)
     if make_hvp:
         row_hvp, col_hvp, data_hvp = eqs.hvp.jac1.parse_row_col_data()
     else:
@@ -231,8 +303,13 @@ def print_module_code(code_dict: Dict[str, str], numba=False):
     code = 'from .dependency import *\n'
     code += """_data_ = setting["data"]\n"""
     code += """_data_hvp = setting["data_hvp"]\n"""
-    code += """_F_ = zeros_like(y__, dtype=float64)"""
-    code += '\n\r\n'
+    code += """_F_ = zeros_like(y__, dtype=float64)\n"""
+    # Load mutable matrix block mapping arrays from setting at module-level
+    # so the J_ wrapper can reference them directly (and numba sees typed
+    # numpy arrays).
+    for mapping_key in code_dict.get('mut_mat_mapping_keys', []):
+        code += f'{mapping_key} = setting["{mapping_key}"]\n'
+    code += '\r\n'
     for tfunc in code_dict['tfunc_dict'].values():
         if numba:
             code += '@njit(cache=True)\n'
@@ -249,10 +326,12 @@ def print_module_code(code_dict: Dict[str, str], numba=False):
     no_njit_J = code_dict.get('no_njit_sub_inner_J', set())
     has_mat_mul_F = len(no_njit_F) > 0
     has_mat_mul_J = len(no_njit_J) > 0
+    no_njit_inner_F = code_dict.get('no_njit_inner_F', False)
+    no_njit_inner_J = code_dict.get('no_njit_inner_J', False)
 
     code += code_dict['F']
     code += '\n\r\n'
-    if numba and not has_mat_mul_F:
+    if numba and not has_mat_mul_F and not no_njit_inner_F:
         code += '@njit(cache=True)\n'
     code += code_dict['inner_F']
     code += '\n\r\n'
@@ -262,9 +341,17 @@ def print_module_code(code_dict: Dict[str, str], numba=False):
         code += sub_func
         code += '\n\r\n'
 
+    # Mutable matrix block @njit functions must be defined BEFORE J_ wrapper
+    # (which calls them). They're pure scatter-add loops, always @njit-able.
+    for block_func in code_dict.get('mut_mat_block_funcs', []):
+        if numba:
+            code += '@njit(cache=True)\n'
+        code += block_func
+        code += '\n\r\n'
+
     code += code_dict['J']
     code += '\n\r\n'
-    if numba and not has_mat_mul_J:
+    if numba and not has_mat_mul_J and not no_njit_inner_J:
         code += '@njit(cache=True)\n'
     code += code_dict['inner_J']
     code += '\n\r\n'

--- a/Solverz/code_printer/python/module/module_printer.py
+++ b/Solverz/code_printer/python/module/module_printer.py
@@ -343,6 +343,31 @@ def print_inner_J(var_addr: Address,
             'mut_mat_mappings': mut_mat_mappings}
 
 
+def _is_csc_matvec_fast_path(matrix_arg, PARAM):
+    """Whether a ``Mat_Mul(matrix_arg, operand)`` placeholder can be
+    computed by the Numba ``SolCF.csc_matvec`` helper inside
+    ``inner_F`` instead of a scipy SpMV in the Python ``F_`` wrapper.
+
+    The condition is strict: the matrix must be a bare ``Para`` (no
+    ``Mul(-1, ...)``, no nested expression) backed by a
+    ``Param(dim=2, sparse=True)`` in the equation's ``PARAM`` dict.
+    Those matrices already have their CSC decomposition
+    (``_data``/``_indices``/``_indptr``/``_shape0``) emitted into
+    ``inner_F``'s argument list by ``print_param``, so the fast path
+    just assembles the matvec call.
+
+    Anything else (negated matrices, matrix-matrix products,
+    operands that are themselves placeholder iVars, dense dim=2
+    params) falls back to the existing scipy SpMV path in ``F_``.
+    """
+    if not isinstance(matrix_arg, Para):
+        return False
+    if matrix_arg.name not in PARAM:
+        return False
+    p = PARAM[matrix_arg.name]
+    return getattr(p, 'dim', 0) == 2 and getattr(p, 'sparse', False)
+
+
 def print_F(eqs_type: str,
             var_addr: Address,
             PARAM: Dict[str, ParamBase],
@@ -350,10 +375,19 @@ def print_F(eqs_type: str,
             precompute_info=None):
     """Print the F_ wrapper.
 
-    When ``precompute_info`` is provided (from ``print_sub_inner_F``), the
-    wrapper precomputes all Mat_Mul products (``_mmN = A @ x``) using
-    scipy.sparse before calling the @njit-able ``inner_F``. The placeholder
-    vectors replace the sparse matrix parameters in the inner function args.
+    ``Mat_Mul(A, x)`` precomputes are split into two paths:
+
+    - **Fast path** — ``A`` is a plain sparse ``dim=2`` ``Para``. The
+      matvec is emitted into ``inner_F`` via ``SolCF.csc_matvec`` and
+      the wrapper does **not** need to do anything: the CSC fields
+      (``A_data`` / ``A_indices`` / ``A_indptr`` / ``A_shape0``) are
+      already in ``param_list`` via ``print_param`` and flow through
+      to ``inner_F`` as normal numpy arrays.
+    - **Fallback** — ``A`` is a non-trivial expression (negated
+      matrix, nested ``Mat_Mul`` etc.). The old path is kept:
+      ``_sz_mm_N = A @ operand`` is emitted as a scipy SpMV inside
+      the wrapper and ``_sz_mm_N`` is passed to ``inner_F`` as an
+      extra dense argument.
     """
     fp = print_F_J_prototype(eqs_type,
                              'F_',
@@ -362,14 +396,49 @@ def print_F(eqs_type: str,
     var_assignments, var_list = print_var(var_addr,
                                           nstep)
     body.extend(var_assignments)
-    # Sparse matrices must be loaded in the wrapper so they can be used for
-    # precompute, but they are NOT in the param_list passed to inner_F.
     param_assignments, param_list = print_param(PARAM,
                                                 include_sparse_in_list=False)
-    body.extend(param_assignments)
+
+    # Identify sparse dim=2 Paras that are *only* used as fast-path
+    # ``Mat_Mul`` matrix operands. These don't need to be loaded in
+    # the wrapper at all — their CSC decomposition
+    # (``<name>_data``/``_indices``/``_indptr``/``_shape0``) already
+    # flows through ``param_list`` to ``inner_F`` and the fast-path
+    # matvec runs entirely inside ``inner_F``. Loading the whole
+    # sparse matrix in the wrapper would be dead work.
+    fallback_mat_symbols = set()
+    if precompute_info:
+        for eqn_info in precompute_info:
+            for _, matrix_arg, _ in eqn_info['matmuls']:
+                if _is_csc_matvec_fast_path(matrix_arg, PARAM):
+                    continue
+                # Fallback case: any Para shown inside the fallback
+                # matrix_arg is still needed in the wrapper for the
+                # scipy SpMV to execute correctly.
+                if hasattr(matrix_arg, 'free_symbols'):
+                    for s in matrix_arg.free_symbols:
+                        if isinstance(s, Para):
+                            fallback_mat_symbols.add(s.name)
+
+    # Filter param_assignments: drop sparse dim=2 loads whose matrix
+    # is never referenced outside fast-path Mat_Mul.
+    filtered_assignments = []
+    for assign in param_assignments:
+        lhs_name = getattr(assign.lhs, 'name', None)
+        if lhs_name and lhs_name in PARAM:
+            p_obj = PARAM[lhs_name]
+            if (getattr(p_obj, 'dim', 0) == 2
+                    and getattr(p_obj, 'sparse', False)
+                    and lhs_name not in fallback_mat_symbols):
+                continue  # fast-path only, no need to load in wrapper
+        filtered_assignments.append(assign)
+    body.extend(filtered_assignments)
     body.extend(print_trigger(PARAM))
 
-    # Generate precompute assignments: _mmN = matrix @ operand
+    # Generate precompute assignments for fallback placeholders only:
+    # ``_sz_mm_N = matrix_arg @ operand_arg``. Fast-path placeholders
+    # are handled inside ``inner_F`` via ``SolCF.csc_matvec`` and do
+    # not need a wrapper-level precompute.
     inner_extra_args = []
     if precompute_info:
         seen_placeholders = set()
@@ -378,7 +447,9 @@ def print_F(eqs_type: str,
                 if placeholder.name in seen_placeholders:
                     continue
                 seen_placeholders.add(placeholder.name)
-                # _mmN = matrix_arg @ operand_arg
+                if _is_csc_matvec_fast_path(matrix_arg, PARAM):
+                    continue
+                # Fallback: _sz_mm_N = matrix_arg @ operand_arg
                 body.append(Assignment(placeholder,
                                        Mat_Mul(matrix_arg, operand_arg)))
                 inner_extra_args.append(symbols(placeholder.name, real=True))
@@ -396,25 +467,73 @@ def print_inner_F(EQNs: Dict[str, Eqn],
                   PARAM: Dict[str, ParamBase],
                   nstep: int = 0,
                   precompute_info=None):
+    """Print the @njit ``inner_F`` dispatcher.
+
+    For fast-path ``Mat_Mul(A, op)`` placeholders (where ``A`` is a
+    plain sparse ``dim=2`` ``Para``), this function emits an explicit
+    ``_sz_mm_N = SolCF.csc_matvec(A_data, A_indices, A_indptr,
+    A_shape0, op)`` assignment at the top of the body and treats
+    ``_sz_mm_N`` as a local variable inside the function. The CSC
+    fields are already in ``param_list`` (emitted by ``print_param``
+    as part of ``model.basic``'s sparse-matrix decomposition), so no
+    additional arguments are needed.
+
+    For fallback placeholders (non-``Para`` matrices), the old path
+    is preserved: the ``F_`` wrapper computes ``_sz_mm_N`` via scipy
+    SpMV and passes it as an extra argument; ``inner_F`` receives it
+    the same way it receives any other dense vector.
+    """
     var_assignments, var_list = print_var(var_addr,
                                           nstep)
-    # inner_F does not receive sparse matrices; they live only in F_ wrapper
-    # for precompute. Placeholders (_mmN) are appended as extra dense args.
     param_assignments, param_list = print_param(PARAM,
                                                 include_sparse_in_list=False)
     args = []
     for var in var_list + param_list:
         args.append(symbols(var.name, real=True))
-    # Append Mat_Mul placeholder args (in the same order as in print_F)
+
+    # Classify each placeholder as fast-path (handled inline via
+    # SolCF.csc_matvec) vs fallback (passed as arg from the wrapper).
+    fast_path_matvec = []  # list of (placeholder_iVar, matrix_name, operand_expr)
+    fallback_placeholders = []  # list of iVar
     if precompute_info:
         seen = set()
         for eqn_info in precompute_info:
-            for placeholder, _, _ in eqn_info['matmuls']:
-                if placeholder.name not in seen:
-                    seen.add(placeholder.name)
-                    args.append(symbols(placeholder.name, real=True))
+            for placeholder, matrix_arg, operand_arg in eqn_info['matmuls']:
+                if placeholder.name in seen:
+                    continue
+                seen.add(placeholder.name)
+                if _is_csc_matvec_fast_path(matrix_arg, PARAM):
+                    fast_path_matvec.append(
+                        (placeholder, matrix_arg.name, operand_arg))
+                else:
+                    fallback_placeholders.append(placeholder)
+
+    # Fallback placeholders come in as extra arguments (old path).
+    for placeholder in fallback_placeholders:
+        args.append(symbols(placeholder.name, real=True))
+
     fp = FunctionPrototype(real, 'inner_F', [symbols('_F_', real=True)] + args)
     body = []
+
+    # Emit the fast-path matvec prelude before any equation assignments.
+    # Each fast placeholder becomes:
+    #   _sz_mm_N = SolCF.csc_matvec(<A>_data, <A>_indices,
+    #                               <A>_indptr, <A>_shape0, operand)
+    # where A_data / A_indices / A_indptr / A_shape0 are already in
+    # ``param_list`` (hence in the function's local scope). Numba
+    # sees SolCF.csc_matvec via the module-level import and can call
+    # it without leaving @njit land.
+    for placeholder, mat_name, operand_arg in fast_path_matvec:
+        body.append(Assignment(
+            iVar(placeholder.name, internal_use=True),
+            FunctionCall(
+                'SolCF.csc_matvec',
+                [symbols(f'{mat_name}_data', real=True),
+                 symbols(f'{mat_name}_indices', real=True),
+                 symbols(f'{mat_name}_indptr', real=True),
+                 symbols(f'{mat_name}_shape0', real=True),
+                 operand_arg])))
+
     body.extend(print_eqn_assignment_with_precompute(EQNs,
                                                      EqnAddr,
                                                      precompute_info))

--- a/Solverz/code_printer/python/module/module_printer.py
+++ b/Solverz/code_printer/python/module/module_printer.py
@@ -7,7 +7,6 @@ from Solverz.code_printer.python.module.mutable_mat_analyzer import (
     analyze_mutable_mat_expr,
     generate_block_function_code,
     MutableMatBlockMapping,
-    _var_base_name as _mut_mat_var_base,
 )
 
 
@@ -140,7 +139,6 @@ def print_J(eqs_type: str,
             PARAM: Dict[str, ParamBase],
             shape: List[int],
             nstep: int = 0,
-            include_sparse_in_list: bool = False,
             mutable_matrix_blocks=None):
     if eqn_size != var_addr.total_size:
         raise ValueError(f"Jac matrix, with size ({eqn_size}*{var_addr.total_size}), not square")
@@ -228,8 +226,7 @@ def print_J(eqs_type: str,
 def print_inner_J(var_addr: Address,
                   PARAM: Dict[str, ParamBase],
                   jac: Jac,
-                  nstep: int = 0,
-                  include_sparse_in_list: bool = False):
+                  nstep: int = 0):
     var_assignments, var_list = print_var(var_addr,
                                           nstep)
     # inner_J must not receive sparse matrices (they're handled in J_ wrapper).
@@ -350,7 +347,6 @@ def print_F(eqs_type: str,
             var_addr: Address,
             PARAM: Dict[str, ParamBase],
             nstep: int = 0,
-            include_sparse_in_list: bool = False,
             precompute_info=None):
     """Print the F_ wrapper.
 
@@ -399,7 +395,6 @@ def print_inner_F(EQNs: Dict[str, Eqn],
                   var_addr: Address,
                   PARAM: Dict[str, ParamBase],
                   nstep: int = 0,
-                  include_sparse_in_list: bool = False,
                   precompute_info=None):
     var_assignments, var_list = print_var(var_addr,
                                           nstep)

--- a/Solverz/code_printer/python/module/module_printer.py
+++ b/Solverz/code_printer/python/module/module_printer.py
@@ -1,7 +1,68 @@
 from __future__ import annotations
 
 import numpy as np
+from sympy import Function
 from Solverz.code_printer.python.utilities import *
+from Solverz.code_printer.python.module.mutable_mat_analyzer import (
+    analyze_mutable_mat_expr,
+    generate_block_function_code,
+    MutableMatBlockMapping,
+    _var_base_name as _mut_mat_var_base,
+)
+
+
+class MutableMatJacDataModule(Function):
+    """Evaluate a mutable matrix Jacobian expression and extract data.
+
+    The slower-but-always-correct fallback used when the symbolic
+    analyser cannot decompose a block into the diag / row-scale /
+    col-scale terms that the vectorised fast path understands.
+
+    The input expression has ``Diag`` replaced by ``SpDiag`` so the
+    printed code uses ``sps.diags`` (not ``np.diagflat``) wherever
+    ``Diag`` appears — sparse matrix products stay sparse, avoiding
+    dense blowup for the common case of sparse parameters.
+
+    However, when the block mixes sparse and dense ``dim=2``
+    parameters, the evaluated expression can collapse to a numpy
+    ``ndarray`` which does NOT have a ``.tocsr()`` method. The
+    generated code therefore dispatches on ``issparse(...)`` at
+    runtime, using sparse fancy indexing for sparse results and dense
+    advanced indexing for ndarray results.
+
+    Generated code (conceptually)::
+
+        _sz_fb = (sparse_expr)
+        data[...] = (asarray(_sz_fb.tocsr()[[rows],[cols]]).ravel()
+                     if sps.issparse(_sz_fb)
+                     else asarray(_sz_fb)[rows, cols])
+    """
+
+    def __new__(cls, expr, coo_row, coo_col):
+        # Substitute Diag → SpDiag so the printed code uses sps.diags
+        # where the expression is naturally sparse. ``SpDiag`` still
+        # collapses correctly when its argument is a dense ndarray.
+        sparse_expr = expr.replace(Diag, SpDiag)
+        obj = super().__new__(cls, sparse_expr)
+        obj._coo_row = coo_row.tolist()
+        obj._coo_col = coo_col.tolist()
+        return obj
+
+    def _numpycode(self, printer, **kwargs):
+        inner = printer._print(self.args[0])
+        rows = self._coo_row
+        cols = self._coo_col
+        # Delegate to a runtime helper that dispatches between sparse
+        # and dense results. ``SolCF.mutable_mat_fallback_extract`` lives
+        # in ``Solverz.num_api.custom_function`` and is imported via
+        # ``module_parser`` into every generated module.
+        return (
+            f'SolCF.mutable_mat_fallback_extract('
+            f'{inner}, {rows}, {cols})'
+        )
+
+    def _pythoncode(self, printer, **kwargs):
+        return self._numpycode(printer, **kwargs)
 
 
 # %%
@@ -79,7 +140,8 @@ def print_J(eqs_type: str,
             PARAM: Dict[str, ParamBase],
             shape: List[int],
             nstep: int = 0,
-            include_sparse_in_list: bool = False):
+            include_sparse_in_list: bool = False,
+            mutable_matrix_blocks=None):
     if eqn_size != var_addr.total_size:
         raise ValueError(f"Jac matrix, with size ({eqn_size}*{var_addr.total_size}), not square")
     fp = print_F_J_prototype(eqs_type,
@@ -89,12 +151,75 @@ def print_J(eqs_type: str,
     var_assignments, var_list = print_var(var_addr,
                                           nstep)
     body.extend(var_assignments)
+    # Load sparse matrices for use in J_ wrapper (mutable matrix blocks),
+    # but do NOT pass them to inner_J (which is @njit-able).
     param_assignments, param_list = print_param(PARAM,
-                                                include_sparse_in_list=include_sparse_in_list)
+                                                include_sparse_in_list=False)
     body.extend(param_assignments)
     body.extend(print_trigger(PARAM))
     body.extend([Assignment(iVar('data', internal_use=True),
                             FunctionCall('inner_J', [symbols('_data_', real=True)] + var_list + param_list))])
+    # Mutable matrix Jacobian blocks. Two modes:
+    #
+    # 1. 'vectorized' — the block's expression is a sum of recognised term
+    #    shapes (Diag, Diag@Matrix, Matrix@Diag). The block's data array is
+    #    assembled by a dedicated generated block function that uses pure
+    #    scatter-add loops over precomputed index mappings. This is the fast
+    #    path — no scipy.sparse matrix construction per J call.
+    #
+    # 2. 'fallback' — some term couldn't be classified; fall back to the
+    #    slower-but-correct scipy sparse + fancy indexing path via
+    #    ``MutableMatJacDataModule``.
+    if mutable_matrix_blocks:
+        for mb in mutable_matrix_blocks:
+            if mb.get('mode') == 'vectorized':
+                mapping = mb['mapping']
+                block_idx = mb['block_idx']
+                # (a) Pre-compute every dense vector the kernel needs —
+                # diag inner vectors AND row/col-scale scaling vectors —
+                # here in the wrapper, where scipy.sparse is available.
+                # The kernel itself then runs scatter-add loops only.
+                # Helper placeholder names begin with the reserved
+                # prefix ``_sz_mb_``; pass ``internal_use=True`` so the
+                # SolSymBasic reserved-prefix guard lets them through.
+                for arg_name, t in zip(mb['diag_arg_names'], mapping.diag_terms):
+                    body.append(Assignment(
+                        iVar(arg_name, internal_use=True), t['inner_expr']))
+                for arg_name, t in zip(mb['rs_arg_names'], mapping.row_scale_terms):
+                    body.append(Assignment(
+                        iVar(arg_name, internal_use=True), t['var_expr']))
+                for arg_name, t in zip(mb['cs_arg_names'], mapping.col_scale_terms):
+                    body.append(Assignment(
+                        iVar(arg_name, internal_use=True), t['var_expr']))
+                # (b) Build the call argument list in the order the block
+                # function expects.
+                call_args = []
+                for arg_name in mb['diag_arg_names']:
+                    call_args.append(symbols(arg_name, real=True))
+                for arg_name in mb['rs_arg_names']:
+                    call_args.append(symbols(arg_name, real=True))
+                for arg_name in mb['cs_arg_names']:
+                    call_args.append(symbols(arg_name, real=True))
+                # Mapping arrays (loaded at module-level from setting)
+                for ti in range(len(mapping.diag_terms)):
+                    call_args.append(symbols(f'_sz_mb_{block_idx}_diag_out_{ti}', real=True))
+                    call_args.append(symbols(f'_sz_mb_{block_idx}_diag_src_{ti}', real=True))
+                for ti in range(len(mapping.row_scale_terms)):
+                    call_args.append(symbols(f'_sz_mb_{block_idx}_rs_out_{ti}', real=True))
+                    call_args.append(symbols(f'_sz_mb_{block_idx}_rs_src_{ti}', real=True))
+                    call_args.append(symbols(f'_sz_mb_{block_idx}_rs_dat_{ti}', real=True))
+                for ti in range(len(mapping.col_scale_terms)):
+                    call_args.append(symbols(f'_sz_mb_{block_idx}_cs_out_{ti}', real=True))
+                    call_args.append(symbols(f'_sz_mb_{block_idx}_cs_src_{ti}', real=True))
+                    call_args.append(symbols(f'_sz_mb_{block_idx}_cs_dat_{ti}', real=True))
+                body.append(Assignment(
+                    iVar('data', internal_use=True)[mb['addr_slice']],
+                    FunctionCall(mb['fn_name'], call_args)))
+            else:
+                # Fallback: scipy sparse fancy indexing
+                body.append(Assignment(
+                    iVar('data', internal_use=True)[mb['addr_slice']],
+                    MutableMatJacDataModule(mb['expr'], mb['coo_row'], mb['coo_col'])))
     body.extend([Return(coo_2_csc(shape[0], shape[1]))])
     fd = FunctionDefinition.from_FunctionPrototype(fp, body)
     return pycode(fd, fully_qualified_modules=False)
@@ -107,8 +232,9 @@ def print_inner_J(var_addr: Address,
                   include_sparse_in_list: bool = False):
     var_assignments, var_list = print_var(var_addr,
                                           nstep)
+    # inner_J must not receive sparse matrices (they're handled in J_ wrapper).
     param_assignments, param_list = print_param(PARAM,
-                                                include_sparse_in_list=include_sparse_in_list)
+                                                include_sparse_in_list=False)
     args = []
     for var in var_list + param_list:
         args.append(symbols(var.name, real=True))
@@ -116,8 +242,13 @@ def print_inner_J(var_addr: Address,
     body = []
 
     code_sub_inner_J_blocks = []
+    no_njit_indices = set()
+    mutable_matrix_blocks = []
+    mut_mat_block_funcs = []  # generated @njit block function sources
+    mut_mat_mappings = {}     # arrays to store in eqn_parameter (setting)
     count = 0
     addr_by_ele_0 = 0
+    eqn_size_by_name = {}
     for eqn_name, jbs_row in jac.blocks_sorted.items():
         for var, jb in jbs_row.items():
             rhs = jb.SpDeriExpr
@@ -129,6 +260,58 @@ def print_inner_J(var_addr: Address,
             jac_constant = jb.IsDeriNumber
 
             if jb.DeriType == 'matrix':
+                if jb.is_mutable_matrix:
+                    # Mutable matrix derivative: analyze the expression into
+                    # typed terms (diag / row_scale / col_scale), generate a
+                    # dedicated loop-based block function, and record the
+                    # precomputed index mapping arrays so the runtime J_ can
+                    # assemble this block's data with pure numpy/numba scatter
+                    # loops — no scipy.sparse construction at every call.
+                    block_idx = len(mutable_matrix_blocks)
+                    eqn_size = jb.EqnAddr.stop - jb.EqnAddr.start
+                    mapping = analyze_mutable_mat_expr(
+                        jb.SpDeriExpr, jb.CooRow, jb.CooCol, PARAM, eqn_size)
+                    block_info = {
+                        'addr_slice': addr_by_ele,
+                        'expr': jb.SpDeriExpr,
+                        'coo_row': jb.CooRow,
+                        'coo_col': jb.CooCol,
+                        'block_idx': block_idx,
+                        'mapping': mapping,
+                        'mode': 'vectorized' if not mapping.has_fallback else 'fallback',
+                    }
+                    if not mapping.has_fallback:
+                        # Generate the dedicated block function source.
+                        fn_name = f'_mut_block_{block_idx}'
+                        diag_arg_names = [f'_sz_mb_{block_idx}_u{ti}'
+                                          for ti in range(len(mapping.diag_terms))]
+                        rs_arg_names = [f'_sz_mb_{block_idx}_rsv{ti}'
+                                        for ti in range(len(mapping.row_scale_terms))]
+                        cs_arg_names = [f'_sz_mb_{block_idx}_csv{ti}'
+                                        for ti in range(len(mapping.col_scale_terms))]
+                        block_info['fn_name'] = fn_name
+                        block_info['diag_arg_names'] = diag_arg_names
+                        block_info['rs_arg_names'] = rs_arg_names
+                        block_info['cs_arg_names'] = cs_arg_names
+                        block_code = generate_block_function_code(
+                            fn_name, mapping,
+                            diag_arg_names, rs_arg_names, cs_arg_names)
+                        mut_mat_block_funcs.append(block_code)
+                        # Collect the mapping arrays for the eqn_parameter
+                        for ti, t in enumerate(mapping.diag_terms):
+                            mut_mat_mappings[f'_sz_mb_{block_idx}_diag_out_{ti}'] = t['out_pos']
+                            mut_mat_mappings[f'_sz_mb_{block_idx}_diag_src_{ti}'] = t['src_idx']
+                        for ti, t in enumerate(mapping.row_scale_terms):
+                            mut_mat_mappings[f'_sz_mb_{block_idx}_rs_out_{ti}'] = t['out_pos']
+                            mut_mat_mappings[f'_sz_mb_{block_idx}_rs_src_{ti}'] = t['src']
+                            mut_mat_mappings[f'_sz_mb_{block_idx}_rs_dat_{ti}'] = t['mat_data']
+                        for ti, t in enumerate(mapping.col_scale_terms):
+                            mut_mat_mappings[f'_sz_mb_{block_idx}_cs_out_{ti}'] = t['out_pos']
+                            mut_mat_mappings[f'_sz_mb_{block_idx}_cs_src_{ti}'] = t['src']
+                            mut_mat_mappings[f'_sz_mb_{block_idx}_cs_dat_{ti}'] = t['mat_data']
+                    mutable_matrix_blocks.append(block_info)
+                    addr_by_ele_0 += jb.SpEleSize
+                    continue
                 jac_constant = True
                 # if the matrix derivative is triggerable, then update it in the Jacobian function call
                 if isinstance(jb.DeriExpr, Para):
@@ -156,14 +339,26 @@ def print_inner_J(var_addr: Address,
     body.extend([Return(temp)])
     fd = FunctionDefinition.from_FunctionPrototype(fp, body)
     return {'code_inner_J': pycode(fd, fully_qualified_modules=False),
-            'code_sub_inner_J': code_sub_inner_J_blocks}
+            'code_sub_inner_J': code_sub_inner_J_blocks,
+            'no_njit_sub_inner_J': no_njit_indices,
+            'mutable_matrix_blocks': mutable_matrix_blocks,
+            'mut_mat_block_funcs': mut_mat_block_funcs,
+            'mut_mat_mappings': mut_mat_mappings}
 
 
 def print_F(eqs_type: str,
             var_addr: Address,
             PARAM: Dict[str, ParamBase],
             nstep: int = 0,
-            include_sparse_in_list: bool = False):
+            include_sparse_in_list: bool = False,
+            precompute_info=None):
+    """Print the F_ wrapper.
+
+    When ``precompute_info`` is provided (from ``print_sub_inner_F``), the
+    wrapper precomputes all Mat_Mul products (``_mmN = A @ x``) using
+    scipy.sparse before calling the @njit-able ``inner_F``. The placeholder
+    vectors replace the sparse matrix parameters in the inner function args.
+    """
     fp = print_F_J_prototype(eqs_type,
                              'F_',
                              nstep)
@@ -171,12 +366,30 @@ def print_F(eqs_type: str,
     var_assignments, var_list = print_var(var_addr,
                                           nstep)
     body.extend(var_assignments)
+    # Sparse matrices must be loaded in the wrapper so they can be used for
+    # precompute, but they are NOT in the param_list passed to inner_F.
     param_assignments, param_list = print_param(PARAM,
-                                                include_sparse_in_list=include_sparse_in_list)
+                                                include_sparse_in_list=False)
     body.extend(param_assignments)
     body.extend(print_trigger(PARAM))
+
+    # Generate precompute assignments: _mmN = matrix @ operand
+    inner_extra_args = []
+    if precompute_info:
+        seen_placeholders = set()
+        for eqn_info in precompute_info:
+            for placeholder, matrix_arg, operand_arg in eqn_info['matmuls']:
+                if placeholder.name in seen_placeholders:
+                    continue
+                seen_placeholders.add(placeholder.name)
+                # _mmN = matrix_arg @ operand_arg
+                body.append(Assignment(placeholder,
+                                       Mat_Mul(matrix_arg, operand_arg)))
+                inner_extra_args.append(symbols(placeholder.name, real=True))
+
     body.extend(
-        [Return(FunctionCall('inner_F', [symbols('_F_', real=True)] + var_list + param_list))])
+        [Return(FunctionCall('inner_F',
+                             [symbols('_F_', real=True)] + var_list + param_list + inner_extra_args))])
     fd = FunctionDefinition.from_FunctionPrototype(fp, body)
     return pycode(fd, fully_qualified_modules=False)
 
@@ -186,49 +399,172 @@ def print_inner_F(EQNs: Dict[str, Eqn],
                   var_addr: Address,
                   PARAM: Dict[str, ParamBase],
                   nstep: int = 0,
-                  include_sparse_in_list: bool = False):
+                  include_sparse_in_list: bool = False,
+                  precompute_info=None):
     var_assignments, var_list = print_var(var_addr,
                                           nstep)
+    # inner_F does not receive sparse matrices; they live only in F_ wrapper
+    # for precompute. Placeholders (_mmN) are appended as extra dense args.
     param_assignments, param_list = print_param(PARAM,
-                                                include_sparse_in_list=include_sparse_in_list)
+                                                include_sparse_in_list=False)
     args = []
     for var in var_list + param_list:
         args.append(symbols(var.name, real=True))
+    # Append Mat_Mul placeholder args (in the same order as in print_F)
+    if precompute_info:
+        seen = set()
+        for eqn_info in precompute_info:
+            for placeholder, _, _ in eqn_info['matmuls']:
+                if placeholder.name not in seen:
+                    seen.add(placeholder.name)
+                    args.append(symbols(placeholder.name, real=True))
     fp = FunctionPrototype(real, 'inner_F', [symbols('_F_', real=True)] + args)
     body = []
-    body.extend(print_eqn_assignment(EQNs,
-                                     EqnAddr,
-                                     True))
+    body.extend(print_eqn_assignment_with_precompute(EQNs,
+                                                     EqnAddr,
+                                                     precompute_info))
     temp = iVar('_F_', internal_use=True)
     body.extend([Return(temp)])
     fd = FunctionDefinition.from_FunctionPrototype(fp, body)
     return pycode(fd, fully_qualified_modules=False)
 
 
+def print_eqn_assignment_with_precompute(EQNs, EqnAddr, precompute_info):
+    """Generate _F_[slice] = inner_F{i}(args...) assignments.
+
+    When precompute_info is provided, the args for each sub-function come
+    from the info dict (which has sparse matrices removed and placeholders
+    appended for Mat_Mul equations). For non-Mat_Mul equations, args fall
+    back to eqn.SYMBOLS.values() — exactly the original behavior.
+    """
+    eqn_declaration = []
+    _F_ = iVar('_F_', internal_use=True)
+    if precompute_info is None:
+        return print_eqn_assignment(EQNs, EqnAddr, True)
+    for count, (eqn_name, eqn_info) in enumerate(zip(EQNs.keys(), precompute_info)):
+        eqn_address = EqnAddr[eqn_name]
+        eqn = EQNs[eqn_name]
+        if eqn.mixed_matrix_vector:
+            sub_args = [symbols(a.name, real=True) for a in eqn_info['args']]
+        else:
+            # Preserve original behavior for non-matrix equations
+            sub_args = list(eqn.SYMBOLS.values())
+        eqn_declaration.append(Assignment(_F_[eqn_address],
+                                          FunctionCall(f'inner_F{int(count)}', sub_args)))
+    return eqn_declaration
+
+
 def print_sub_inner_F(EQNs: Dict[str, Eqn]):
     """Generate inner_F0, inner_F1, ... sub-functions, one per equation.
+
+    For equations containing Mat_Mul, extract the matrix-vector products and
+    replace them with placeholder variables (_sz_mm_0, _sz_mm_1, ...). The
+    placeholders are computed in the F_ wrapper (scipy.sparse) and passed in
+    as dense vectors. This allows the sub-functions to remain @njit-friendly
+    even when the original equation uses sparse matrices.
 
     Returns
     -------
     code_blocks : list of str
         Generated code for each sub-function.
-    no_njit_indices : set of int
-        Indices of sub-functions that use Mat_Mul and therefore must NOT
-        be decorated with @njit (they receive scipy.sparse matrices).
+    precompute_info : list of dict
+        Per-equation metadata. Each dict has:
+        - 'eqn_name': name of the equation
+        - 'new_rhs': RHS with Mat_Mul replaced by placeholders
+        - 'matmuls': list of (placeholder_iVar, matrix_arg, operand_arg)
+        - 'args': ordered list of argument symbols for inner_F{i}
+        - 'matrix_symbols_removed': set of symbol names dropped from args
+          (sparse matrix params that only appear inside Mat_Mul)
     """
     code_blocks = []
-    no_njit_indices = set()
+    precompute_info = []
+    # Global Mat_Mul cache: (matrix_arg, operand_arg) -> global placeholder iVar.
+    # Shared across all equations so that identical Mat_Mul patterns are
+    # computed only once in the F_ wrapper. SymPy's structural equality
+    # makes the dict lookup hit on matching expressions.
+    mm_cache = {}
+    global_mm_counter = [0]
     count = 0
-    for eqn_name in EQNs.keys():
-        eqn = EQNs[eqn_name]
-        if eqn.mixed_matrix_vector:
-            no_njit_indices.add(count)
-        args = []
-        for var in eqn.SYMBOLS.keys():
-            args.append(symbols(var, real=True))
-        fp = FunctionPrototype(real, f'inner_F{count}', args)
-        body = [Return(eqn.RHS)]
+    for eqn_name, eqn in EQNs.items():
+        # Fast path: non-Mat_Mul equation — original behavior, no changes.
+        if not eqn.mixed_matrix_vector:
+            args = [symbols(v, real=True) for v in eqn.SYMBOLS.keys()]
+            fp = FunctionPrototype(real, f'inner_F{count}', args)
+            body = [Return(eqn.RHS)]
+            fd = FunctionDefinition.from_FunctionPrototype(fp, body)
+            code_blocks.append(pycode(fd, fully_qualified_modules=False))
+            precompute_info.append({
+                'eqn_name': eqn_name,
+                'new_rhs': eqn.RHS,
+                'matmuls': [],
+                'args': args,
+                'matrix_symbols_removed': set(),
+            })
+            count += 1
+            continue
+
+        # Mat_Mul path: extract matrix-vector products into placeholders.
+        new_rhs, matmuls = extract_matmuls(eqn.RHS)
+        # Deduplicate: map each local placeholder to a (possibly shared)
+        # global placeholder using mm_cache.
+        subs_map = {}
+        eqn_matmuls = []  # (placeholder, mat_arg, op_arg) unique to this eqn
+        for placeholder_local, mat_arg, op_arg in matmuls:
+            # Apply in-eqn substitutions so nested Mat_Muls use their
+            # global placeholder names before the cache lookup.
+            if subs_map:
+                if hasattr(mat_arg, 'xreplace'):
+                    mat_arg = mat_arg.xreplace(subs_map)
+                if hasattr(op_arg, 'xreplace'):
+                    op_arg = op_arg.xreplace(subs_map)
+            key = (mat_arg, op_arg)
+            if key in mm_cache:
+                global_placeholder = mm_cache[key]
+            else:
+                new_name = f'_sz_mm_{global_mm_counter[0]}'
+                global_mm_counter[0] += 1
+                global_placeholder = iVar(new_name, internal_use=True)
+                mm_cache[key] = global_placeholder
+            subs_map[placeholder_local] = global_placeholder
+            eqn_matmuls.append((global_placeholder, mat_arg, op_arg))
+        new_rhs = new_rhs.xreplace(subs_map)
+
+        # Determine which original base symbol names remain in new_rhs.
+        # For IdxVar (e.g. x[0:2]), the base name is stored in `name0`;
+        # regular symbols use `name` directly. eqn.SYMBOLS keys are base
+        # names, so we match against the base.
+        remaining_names = set()
+        for s in new_rhs.free_symbols:
+            if hasattr(s, 'name0'):
+                remaining_names.add(s.name0)
+            else:
+                remaining_names.add(getattr(s, 'name', str(s)))
+
+        ordered_args = []
+        matrix_symbols_removed = set()
+        for name in eqn.SYMBOLS.keys():
+            if name in remaining_names:
+                ordered_args.append(symbols(name, real=True))
+            else:
+                matrix_symbols_removed.add(name)
+        # Append placeholders needed by this eqn (skip duplicates)
+        seen_in_eqn = set()
+        for ph, _, _ in eqn_matmuls:
+            if ph.name not in seen_in_eqn:
+                seen_in_eqn.add(ph.name)
+                ordered_args.append(symbols(ph.name, real=True))
+
+        fp = FunctionPrototype(real, f'inner_F{count}', ordered_args)
+        body = [Return(new_rhs)]
         fd = FunctionDefinition.from_FunctionPrototype(fp, body)
-        count = count + 1
         code_blocks.append(pycode(fd, fully_qualified_modules=False))
-    return code_blocks, no_njit_indices
+
+        precompute_info.append({
+            'eqn_name': eqn_name,
+            'new_rhs': new_rhs,
+            'matmuls': eqn_matmuls,
+            'args': ordered_args,
+            'matrix_symbols_removed': matrix_symbols_removed,
+        })
+        count += 1
+    return code_blocks, precompute_info

--- a/Solverz/code_printer/python/module/module_printer.py
+++ b/Solverz/code_printer/python/module/module_printer.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any, Set, Tuple
+
 import numpy as np
 from sympy import Function
 from Solverz.code_printer.python.utilities import *
@@ -343,29 +345,154 @@ def print_inner_J(var_addr: Address,
             'mut_mat_mappings': mut_mat_mappings}
 
 
-def _is_csc_matvec_fast_path(matrix_arg, PARAM):
-    """Whether a ``Mat_Mul(matrix_arg, operand)`` placeholder can be
-    computed by the Numba ``SolCF.csc_matvec`` helper inside
-    ``inner_F`` instead of a scipy SpMV in the Python ``F_`` wrapper.
+def _classify_matmul_placeholders(precompute_info, PARAM):
+    """Classify every extracted ``Mat_Mul`` placeholder into fast /
+    fallback and compute which ``Para`` symbols the fallback code
+    path still needs to have loaded in the ``F_`` wrapper.
 
-    The condition is strict: the matrix must be a bare ``Para`` (no
-    ``Mul(-1, ...)``, no nested expression) backed by a
-    ``Param(dim=2, sparse=True)`` in the equation's ``PARAM`` dict.
-    Those matrices already have their CSC decomposition
-    (``_data``/``_indices``/``_indptr``/``_shape0``) emitted into
-    ``inner_F``'s argument list by ``print_param``, so the fast path
-    just assembles the matvec call.
+    This replaces the earlier per-placeholder ``_is_csc_matvec_fast_path``
+    check, which looked only at ``matrix_arg`` and did not account for
+    three concrete regressions that broke generated code:
 
-    Anything else (negated matrices, matrix-matrix products,
-    operands that are themselves placeholder iVars, dense dim=2
-    params) falls back to the existing scipy SpMV path in ``F_``.
+    1. **Nested fallbacks referencing fast placeholders** — e.g.
+       ``Mat_Mul(-A, Mat_Mul(B, x))``. ``extract_matmuls`` visits the
+       inner ``Mat_Mul(B, x)`` first and produces placeholder
+       ``_sz_mm_0``; the outer's matrix is ``-A`` (fallback) and its
+       operand is ``_sz_mm_0``. A naive classifier marks ``_sz_mm_0``
+       as fast (matrix is a bare ``Para``) but the outer fallback
+       still expects ``_sz_mm_0`` to be materialised in the wrapper
+       before its scipy SpMV runs, so the wrapper emits a reference
+       to an undefined name.
+
+    2. **Unresolved matrix factors in the operand** — e.g.
+       ``Mat_Mul(A, B, x)``. Solverz's ``Mat_Mul`` accepts any number
+       of arguments; ``extract_matmuls`` folds 3+-arg nodes into
+       ``matrix_arg = A`` / ``operand_arg = Mat_Mul(B, x)``, and the
+       freshly-constructed inner ``Mat_Mul(B, x)`` is not re-walked.
+       A classifier that accepts this as fast would feed
+       ``Mat_Mul(B, x)`` into ``SolCF.csc_matvec`` as if it were a
+       plain vector, which either crashes (``B`` isn't in ``inner_F``'s
+       argument list) or silently produces wrong results.
+
+    3. **Sparse matrix references in the operand** — e.g. an operand
+       expression that still contains a sparse ``dim=2`` ``Para``
+       symbol. These symbols are not in ``inner_F``'s argument list
+       (only their CSC flat fields are), so inlining the operand
+       inside ``inner_F`` would reference an undefined name.
+
+    The algorithm is a two-pass fixed point:
+
+    - **Shape filter** — a placeholder is a *fast candidate* iff its
+      ``matrix_arg`` is a bare sparse ``dim=2`` ``Para`` **and** its
+      ``operand_arg`` contains neither ``Mat_Mul`` atoms nor sparse
+      ``dim=2`` ``Para`` references.
+    - **Demotion** — any fast candidate whose name appears as a free
+      symbol in another (non-fast) placeholder's ``matrix_arg`` or
+      ``operand_arg`` is demoted to fallback. The scan repeats until
+      no more demotions happen (needed because demotion can cascade
+      in a chain of nested ``Mat_Mul``s, though this is rare).
+
+    Returns
+    -------
+    fast_info : dict[str, tuple[str, sympy.Expr]]
+        Maps a fast-path placeholder's name to ``(matrix_name,
+        operand_arg)`` so callers can emit the
+        ``SolCF.csc_matvec(<m>_data, ..., operand)`` call directly.
+    fallback_names : set[str]
+        Names of placeholders that must be computed in the ``F_``
+        wrapper (via scipy) and passed through ``inner_F`` as extra
+        arguments.
+    fallback_symbols : set[str]
+        Para names that appear anywhere in a fallback placeholder's
+        ``matrix_arg`` or ``operand_arg``. The wrapper must load each
+        of these (``A = p_["A"]``) or the scipy evaluation below
+        fails.
     """
-    if not isinstance(matrix_arg, Para):
-        return False
-    if matrix_arg.name not in PARAM:
-        return False
-    p = PARAM[matrix_arg.name]
-    return getattr(p, 'dim', 0) == 2 and getattr(p, 'sparse', False)
+    fast_info: Dict[str, Tuple[str, Any]] = {}
+    fallback_names: Set[str] = set()
+    fallback_symbols: Set[str] = set()
+
+    if not precompute_info:
+        return fast_info, fallback_names, fallback_symbols
+
+    # Gather (name, matrix_arg, operand_arg) triples, deduped by name.
+    all_triples: List[Tuple[str, Any, Any]] = []
+    seen: Set[str] = set()
+    for eqn_info in precompute_info:
+        for placeholder, matrix_arg, operand_arg in eqn_info['matmuls']:
+            if placeholder.name in seen:
+                continue
+            seen.add(placeholder.name)
+            all_triples.append((placeholder.name, matrix_arg, operand_arg))
+
+    def _shape_is_fast(mat, op):
+        # matrix_arg must be a bare sparse dim=2 Para
+        if not isinstance(mat, Para):
+            return False
+        if mat.name not in PARAM:
+            return False
+        p = PARAM[mat.name]
+        if not (getattr(p, 'dim', 0) == 2
+                and getattr(p, 'sparse', False)):
+            return False
+        # operand_arg must not contain any Mat_Mul node — ``Mat_Mul``
+        # inside an operand means extract_matmuls folded a multi-arg
+        # Mat_Mul and left an inner product unresolved (see R3).
+        if hasattr(op, 'has') and op.has(Mat_Mul):
+            return False
+        # operand_arg must not reference any sparse dim=2 Para — those
+        # are not available by name inside ``inner_F`` (only their CSC
+        # flat fields are), so a direct reference would NameError.
+        if hasattr(op, 'free_symbols'):
+            for s in op.free_symbols:
+                if isinstance(s, Para) and s.name in PARAM:
+                    p_op = PARAM[s.name]
+                    if (getattr(p_op, 'dim', 0) == 2
+                            and getattr(p_op, 'sparse', False)):
+                        return False
+        return True
+
+    # Pass 1 — shape-based classification.
+    fast_candidates: Set[str] = set()
+    for name, mat, op in all_triples:
+        if _shape_is_fast(mat, op):
+            fast_candidates.add(name)
+
+    # Pass 2 — demote fast candidates consumed by any non-fast
+    # placeholder's matrix or operand. Repeat until fixed point so
+    # cascading dependencies propagate.
+    changed = True
+    while changed:
+        changed = False
+        for name, mat, op in all_triples:
+            if name in fast_candidates:
+                continue  # not a consumer of interest — fast placeholders
+                          # cannot create wrapper-side dependencies
+            for expr in (mat, op):
+                if not hasattr(expr, 'free_symbols'):
+                    continue
+                for s in expr.free_symbols:
+                    s_name = getattr(s, 'name', None)
+                    if s_name and s_name in fast_candidates:
+                        fast_candidates.discard(s_name)
+                        changed = True
+
+    # Build the output sets.
+    for name, mat, op in all_triples:
+        if name in fast_candidates:
+            # ``mat`` is guaranteed to be a Para by _shape_is_fast.
+            fast_info[name] = (mat.name, op)
+        else:
+            fallback_names.add(name)
+            # Collect every Para referenced by the fallback expression
+            # so the wrapper filter keeps the corresponding loads.
+            for expr in (mat, op):
+                if hasattr(expr, 'free_symbols'):
+                    for s in expr.free_symbols:
+                        if isinstance(s, Para):
+                            fallback_symbols.add(s.name)
+
+    return fast_info, fallback_names, fallback_symbols
 
 
 def print_F(eqs_type: str,
@@ -399,38 +526,38 @@ def print_F(eqs_type: str,
     param_assignments, param_list = print_param(PARAM,
                                                 include_sparse_in_list=False)
 
-    # Identify sparse dim=2 Paras that are *only* used as fast-path
-    # ``Mat_Mul`` matrix operands. These don't need to be loaded in
-    # the wrapper at all — their CSC decomposition
-    # (``<name>_data``/``_indices``/``_indptr``/``_shape0``) already
-    # flows through ``param_list`` to ``inner_F`` and the fast-path
-    # matvec runs entirely inside ``inner_F``. Loading the whole
-    # sparse matrix in the wrapper would be dead work.
-    fallback_mat_symbols = set()
-    if precompute_info:
-        for eqn_info in precompute_info:
-            for _, matrix_arg, _ in eqn_info['matmuls']:
-                if _is_csc_matvec_fast_path(matrix_arg, PARAM):
-                    continue
-                # Fallback case: any Para shown inside the fallback
-                # matrix_arg is still needed in the wrapper for the
-                # scipy SpMV to execute correctly.
-                if hasattr(matrix_arg, 'free_symbols'):
-                    for s in matrix_arg.free_symbols:
-                        if isinstance(s, Para):
-                            fallback_mat_symbols.add(s.name)
+    # Shared classification (matches what ``print_inner_F`` computes,
+    # see :func:`_classify_matmul_placeholders`). ``fallback_symbols``
+    # names every ``Para`` that the wrapper must still materialise so
+    # the scipy SpMV in a fallback precompute can execute correctly.
+    _, fallback_names, fallback_symbols = _classify_matmul_placeholders(
+        precompute_info, PARAM)
 
-    # Filter param_assignments: drop sparse dim=2 loads whose matrix
-    # is never referenced outside fast-path Mat_Mul.
+    # Drop sparse dim=2 ``Para`` wrapper loads that are (a) not
+    # referenced by any fallback scipy SpMV **and** (b) not in
+    # ``param_list`` — i.e., they are loaded purely as a side-effect
+    # of ``print_param`` but never used downstream. The
+    # ``param_list`` guard is what keeps sparse ``TimeSeriesParam``
+    # loads (``A = p_["A"].get_v_t(t)``) in place: those params are
+    # *in* ``param_list`` because ``print_param``'s TimeSeriesParam
+    # branch appends them, and dropping the wrapper load would leave
+    # ``inner_F(..., A, ...)`` referencing an undefined local.
+    param_list_names = set()
+    for entry in param_list:
+        n = getattr(entry, 'name', None)
+        if n is not None:
+            param_list_names.add(n)
     filtered_assignments = []
     for assign in param_assignments:
         lhs_name = getattr(assign.lhs, 'name', None)
         if lhs_name and lhs_name in PARAM:
             p_obj = PARAM[lhs_name]
-            if (getattr(p_obj, 'dim', 0) == 2
-                    and getattr(p_obj, 'sparse', False)
-                    and lhs_name not in fallback_mat_symbols):
-                continue  # fast-path only, no need to load in wrapper
+            is_sparse_dim2 = (getattr(p_obj, 'dim', 0) == 2
+                              and getattr(p_obj, 'sparse', False))
+            if (is_sparse_dim2
+                    and lhs_name not in fallback_symbols
+                    and lhs_name not in param_list_names):
+                continue  # nothing downstream needs this load
         filtered_assignments.append(assign)
     body.extend(filtered_assignments)
     body.extend(print_trigger(PARAM))
@@ -438,7 +565,10 @@ def print_F(eqs_type: str,
     # Generate precompute assignments for fallback placeholders only:
     # ``_sz_mm_N = matrix_arg @ operand_arg``. Fast-path placeholders
     # are handled inside ``inner_F`` via ``SolCF.csc_matvec`` and do
-    # not need a wrapper-level precompute.
+    # not need a wrapper-level precompute. Iteration order is
+    # precompute_info order, which is ``extract_matmuls`` post-order
+    # (inner Mat_Mul first), so any fallback that references a
+    # previously-demoted fast placeholder sees it defined.
     inner_extra_args = []
     if precompute_info:
         seen_placeholders = set()
@@ -447,8 +577,8 @@ def print_F(eqs_type: str,
                 if placeholder.name in seen_placeholders:
                     continue
                 seen_placeholders.add(placeholder.name)
-                if _is_csc_matvec_fast_path(matrix_arg, PARAM):
-                    continue
+                if placeholder.name not in fallback_names:
+                    continue  # handled inside inner_F
                 # Fallback: _sz_mm_N = matrix_arg @ operand_arg
                 body.append(Assignment(placeholder,
                                        Mat_Mul(matrix_arg, operand_arg)))
@@ -491,21 +621,28 @@ def print_inner_F(EQNs: Dict[str, Eqn],
     for var in var_list + param_list:
         args.append(symbols(var.name, real=True))
 
-    # Classify each placeholder as fast-path (handled inline via
-    # SolCF.csc_matvec) vs fallback (passed as arg from the wrapper).
-    fast_path_matvec = []  # list of (placeholder_iVar, matrix_name, operand_expr)
-    fallback_placeholders = []  # list of iVar
+    # Shared classification with ``print_F``. Both functions must
+    # agree on which placeholders are fast-path vs fallback —
+    # divergence produces ``inner_F`` that either references an
+    # undefined local or receives ``_sz_mm_N`` twice.
+    fast_info, fallback_names, _ = _classify_matmul_placeholders(
+        precompute_info, PARAM)
+
+    # Collect ordered lists for code emission.
+    fast_path_matvec = []   # [(placeholder_iVar, matrix_name, operand)]
+    fallback_placeholders = []  # [iVar]
     if precompute_info:
         seen = set()
         for eqn_info in precompute_info:
-            for placeholder, matrix_arg, operand_arg in eqn_info['matmuls']:
+            for placeholder, _, _ in eqn_info['matmuls']:
                 if placeholder.name in seen:
                     continue
                 seen.add(placeholder.name)
-                if _is_csc_matvec_fast_path(matrix_arg, PARAM):
+                if placeholder.name in fast_info:
+                    mat_name, operand_arg = fast_info[placeholder.name]
                     fast_path_matvec.append(
-                        (placeholder, matrix_arg.name, operand_arg))
-                else:
+                        (placeholder, mat_name, operand_arg))
+                elif placeholder.name in fallback_names:
                     fallback_placeholders.append(placeholder)
 
     # Fallback placeholders come in as extra arguments (old path).

--- a/Solverz/code_printer/python/module/mutable_mat_analyzer.py
+++ b/Solverz/code_printer/python/module/mutable_mat_analyzer.py
@@ -1,0 +1,439 @@
+"""Mutable matrix Jacobian block analyzer.
+
+Decomposes a SymPy derivative expression for a mutable-matrix Jacobian
+block (such as ``Diag(G@e - B@f + p_ref) + Diag(e)@G + Diag(f)@B`` from
+power flow) into a sum of typed *terms*. For each term we precompute the
+mapping from its source indices to positions in the output CSC data array,
+so that the runtime can build the block data with pure numpy/Numba loops
+instead of constructing intermediate scipy sparse matrices at every call.
+
+Recognised term shapes (after flattening ``Mul`` coefficients into a
+``sign`` ∈ {+1, −1}):
+
+1. ``Diag(inner)``
+   Contributes at positions ``(i, i)`` for each ``i`` where ``(i, i)`` is
+   in the output sparsity. Runtime: ``data[out_pos] = sign * inner[src_i]``.
+
+2. ``Mat_Mul(Diag(var), Matrix)``  (row-scaled sparse matrix)
+   The ``Matrix`` must be a fixed ``Para`` (immutable after modelling).
+   Each nnz ``(r, c)`` in ``Matrix`` lands at ``pos_lookup[(r, c)]`` with
+   value ``sign * var[r] * Matrix.data[k]``. Runtime scatter-add over nnz.
+
+3. ``Mat_Mul(Matrix, Diag(var))``  (column-scaled sparse matrix, rare)
+   Symmetric to case 2 but scaled by ``var[c]`` instead of ``var[r]``.
+
+Everything else falls back to scipy sparse evaluation with fancy indexing
+(slow but correct).
+
+The analyzer is pure data — it doesn't touch scipy.sparse at runtime.
+That's the whole point: the expensive sparse-matrix construction happens
+zero times per Newton step.
+"""
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+from sympy import Add, Mul, S, Symbol, Expr, sympify, pycode
+
+from Solverz.sym_algebra.functions import Diag, Mat_Mul
+from Solverz.sym_algebra.symbols import Para, iVar, IdxVar
+
+
+class MutableMatBlockMapping:
+    """Precomputed runtime mapping for one mutable matrix Jacobian block.
+
+    Stores the decomposition of a derivative expression into terms plus
+    the index arrays each term will use at runtime. All attributes are
+    plain numpy arrays / SymPy expressions — no scipy.sparse objects —
+    so they pickle cleanly and compile under Numba.
+
+    Attributes
+    ----------
+    n_out : int
+        Number of entries in the block's contribution to ``_data_``.
+    diag_terms : list of dict
+        Each dict has ``sign`` (±1), ``inner_expr`` (SymPy), ``out_pos``
+        (ndarray[int64]), ``src_idx`` (ndarray[int64]).
+    row_scale_terms : list of dict
+        Each dict has ``sign``, ``var_name`` (str, name of the vector
+        variable), ``matrix_name`` (str, name of the sparse Para),
+        ``out_pos`` (ndarray), ``src_row`` (ndarray), ``mat_data_ref``
+        (ndarray — the matrix's constant .data values, baked in).
+    col_scale_terms : list of dict
+        Symmetric to row_scale but with ``src_col`` instead.
+    fallback_expr : SymPy Expr or None
+        Sum of any unrecognised terms; evaluated via sparse fancy indexing.
+    fallback_out_row, fallback_out_col : ndarray or None
+        COO positions used by the fallback expression at runtime.
+    """
+
+    __slots__ = ('n_out', 'diag_terms', 'row_scale_terms',
+                 'col_scale_terms', 'fallback_expr',
+                 'fallback_out_row', 'fallback_out_col', 'has_fallback')
+
+    def __init__(self, n_out: int):
+        self.n_out = n_out
+        self.diag_terms: List[Dict] = []
+        self.row_scale_terms: List[Dict] = []
+        self.col_scale_terms: List[Dict] = []
+        self.fallback_expr: Optional[Expr] = None
+        self.fallback_out_row: Optional[np.ndarray] = None
+        self.fallback_out_col: Optional[np.ndarray] = None
+        self.has_fallback: bool = False
+
+
+def _extract_sign_and_core(term: Expr) -> Tuple[int, Expr]:
+    """Return ``(sign, core)`` where ``core`` has no leading ±1 coefficient.
+
+    Handles ``-Diag(x)`` → ``(-1, Diag(x))`` and ``Mul(-1, Mat_Mul(...))`` →
+    ``(-1, Mat_Mul(...))``. A non-unit numeric coefficient like 2*Diag(x)
+    is not unwrapped — it gets absorbed into the diag term later.
+    """
+    if isinstance(term, Mul):
+        args = list(term.args)
+        sign = 1
+        rest: List[Expr] = []
+        for a in args:
+            if a == S.NegativeOne:
+                sign *= -1
+            else:
+                rest.append(a)
+        if len(rest) == 1:
+            return sign, rest[0]
+        return sign, Mul(*rest) if rest else S.One
+    return 1, term
+
+
+def _unwrap_negated_para(expr: Expr) -> Tuple[int, Optional[Para]]:
+    """If ``expr`` is ``Para`` or ``-Para``, return ``(sign, Para)``.
+
+    Handles the common case of ``diag(v) @ (-B)`` where SymPy represents
+    ``-B`` as ``Mul(-1, B)``. For anything else, returns ``(1, None)``.
+    """
+    if isinstance(expr, Para):
+        return 1, expr
+    if isinstance(expr, Mul):
+        sign = 1
+        rest: List[Expr] = []
+        for a in expr.args:
+            if a == S.NegativeOne:
+                sign *= -1
+            else:
+                rest.append(a)
+        if len(rest) == 1 and isinstance(rest[0], Para):
+            return sign, rest[0]
+    return 1, None
+
+
+def _classify_matmul(mm: Mat_Mul) -> Optional[Tuple[str, Expr, Para, int]]:
+    """Classify a Mat_Mul as row-scale / col-scale / None.
+
+    Returns ``(kind, var_expr, matrix_para, extra_sign)`` where kind is
+    ``'row_scale'`` or ``'col_scale'``, ``extra_sign`` ∈ {+1, −1} captures
+    a ``Mul(-1, Matrix)`` factor, or ``None`` if the shape is not
+    recognised.
+    """
+    args = list(mm.args)
+    if len(args) != 2:
+        return None
+    left, right = args
+    # Diag(var) @ (±Matrix)
+    if isinstance(left, Diag):
+        sign, para = _unwrap_negated_para(right)
+        if para is not None:
+            return ('row_scale', left.args[0], para, sign)
+    # (±Matrix) @ Diag(var)
+    if isinstance(right, Diag):
+        sign, para = _unwrap_negated_para(left)
+        if para is not None:
+            return ('col_scale', right.args[0], para, sign)
+    return None
+
+
+def _sparse_matrix_nnz(para: Para, PARAM) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return (coo_row, coo_col, data) for a sparse Para's current value.
+
+    The caller promises the matrix is immutable after modelling (see the
+    documentation), so these arrays reflect the baked-in runtime state.
+    """
+    value = PARAM[para.name].get_v_t(0)
+    coo = value.tocoo()
+    return (np.asarray(coo.row, dtype=np.int64),
+            np.asarray(coo.col, dtype=np.int64),
+            np.asarray(coo.data, dtype=np.float64))
+
+
+def analyze_mutable_mat_expr(expr: Expr,
+                              value0_row: np.ndarray,
+                              value0_col: np.ndarray,
+                              PARAM,
+                              eqn_size: int) -> MutableMatBlockMapping:
+    """Decompose ``expr`` and build a :class:`MutableMatBlockMapping`.
+
+    Parameters
+    ----------
+    expr : SymPy Expr
+        The mutable-matrix Jacobian block expression, in SpDeriExpr form
+        (already Mat_Mul-aware, Diag uses the original ``Diag`` class).
+    value0_row, value0_col : ndarray
+        Output sparsity pattern (one entry per nnz in the block's Value0).
+        Obtained from the perturbed ``Value0.tocoo()`` — this is the full
+        structural union of all term patterns.
+    PARAM : dict
+        The equation system's PARAM dict (needed to fetch sparse matrix
+        .data/.indices at analysis time).
+    eqn_size : int
+        The block's equation-axis length (number of rows).
+
+    Returns
+    -------
+    MutableMatBlockMapping
+        Pre-computed mapping with typed term lists. Any terms that
+        don't fit the supported shapes are dropped into ``fallback_expr``.
+    """
+    n_out = len(value0_row)
+    pos_lookup: Dict[Tuple[int, int], int] = {
+        (int(r), int(c)): i
+        for i, (r, c) in enumerate(zip(value0_row, value0_col))
+    }
+    mapping = MutableMatBlockMapping(n_out)
+
+    fallback_pieces: List[Expr] = []
+
+    def handle(term: Expr):
+        sign, core = _extract_sign_and_core(term)
+        # Distribute Mat_Mul over Add in the operand: the matrix-calculus
+        # engine typically emits ``L @ (Diag(u) + Diag(v))`` for the
+        # derivative of ``L @ (u ⊙ m)``, and we need each ``Diag`` term to
+        # be classified independently. Apply the identity
+        # ``A @ (X + Y) = A @ X + A @ Y`` (and the symmetric form) and
+        # recurse into each summand.
+        if isinstance(core, Mat_Mul) and len(core.args) == 2:
+            left, right = core.args
+            if isinstance(right, Add):
+                for sub in right.args:
+                    handle(sign * Mat_Mul(left, sub))
+                return
+            if isinstance(left, Add):
+                for sub in left.args:
+                    handle(sign * Mat_Mul(sub, right))
+                return
+        # Diag(inner)
+        if isinstance(core, Diag):
+            inner = core.args[0]
+            # Identify output positions on the diagonal (row == col)
+            out_pos_list = []
+            src_idx_list = []
+            for i in range(eqn_size):
+                k = pos_lookup.get((i, i))
+                if k is not None:
+                    out_pos_list.append(k)
+                    src_idx_list.append(i)
+            mapping.diag_terms.append({
+                'sign': sign,
+                'inner_expr': inner,
+                'out_pos': np.asarray(out_pos_list, dtype=np.int64),
+                'src_idx': np.asarray(src_idx_list, dtype=np.int64),
+            })
+            return
+        # Mat_Mul(Diag, Matrix) or Mat_Mul(Matrix, Diag)
+        if isinstance(core, Mat_Mul):
+            classification = _classify_matmul(core)
+            if classification is not None:
+                kind, var_expr, matrix_para, extra_sign = classification
+                sign = sign * extra_sign
+                try:
+                    mat_row, mat_col, mat_data = _sparse_matrix_nnz(matrix_para, PARAM)
+                except Exception:
+                    fallback_pieces.append(term)
+                    return
+                out_pos_list = []
+                src_list = []
+                # Build term's nnz → output mapping
+                for k, (r, c) in enumerate(zip(mat_row, mat_col)):
+                    out_k = pos_lookup.get((int(r), int(c)))
+                    if out_k is None:
+                        # This element is not in the init pattern — shouldn't
+                        # happen when Value0 is computed via SpDiag + union,
+                        # but skip safely if it does.
+                        continue
+                    out_pos_list.append(out_k)
+                    src_list.append(int(r) if kind == 'row_scale' else int(c))
+                entry = {
+                    'sign': sign,
+                    'var_expr': var_expr,
+                    'matrix_name': matrix_para.name,
+                    'out_pos': np.asarray(out_pos_list, dtype=np.int64),
+                    'src': np.asarray(src_list, dtype=np.int64),
+                    'mat_data': mat_data,
+                }
+                if kind == 'row_scale':
+                    mapping.row_scale_terms.append(entry)
+                else:
+                    mapping.col_scale_terms.append(entry)
+                return
+        # Anything else — fall back to sparse evaluation
+        fallback_pieces.append(term)
+
+    if isinstance(expr, Add):
+        for t in expr.args:
+            handle(t)
+    else:
+        handle(expr)
+
+    if fallback_pieces:
+        mapping.fallback_expr = Add(*fallback_pieces) if len(fallback_pieces) > 1 else fallback_pieces[0]
+        mapping.fallback_out_row = np.asarray(value0_row, dtype=np.int64)
+        mapping.fallback_out_col = np.asarray(value0_col, dtype=np.int64)
+        mapping.has_fallback = True
+
+    return mapping
+
+
+def generate_block_function_code(fn_name: str,
+                                   mapping: MutableMatBlockMapping,
+                                   diag_arg_names: List[str],
+                                   rs_arg_names: List[str],
+                                   cs_arg_names: List[str]) -> str:
+    """Generate a @njit function that builds one mutable matrix block's
+    data array.
+
+    The generated kernel takes **all** dense vectors — diag inner
+    vectors AND row/col-scale vectors — as arguments, pre-computed by
+    the J_ wrapper. This lets the kernel be completely free of scipy
+    sparse objects and base variable slicing, so it can compile
+    cleanly under Numba regardless of how complex the original
+    ``var_expr`` inside each ``Diag(...)`` was.
+
+    Parameters
+    ----------
+    fn_name : str
+        Name of the generated function, e.g. ``'_mut_block_0'``.
+    mapping : MutableMatBlockMapping
+        The pre-computed decomposition of the block.
+    diag_arg_names : list of str
+        Per-diag-term inner vector argument names. Length =
+        ``len(mapping.diag_terms)``.
+    rs_arg_names : list of str
+        Per-row-scale-term scaling vector argument names. Length =
+        ``len(mapping.row_scale_terms)``. For a term
+        ``Mat_Mul(Diag(v_expr), M)`` this vector is ``v_expr`` evaluated
+        as a dense vector in the wrapper, and the kernel reads
+        ``rsv[src[k]]`` per nonzero of M.
+    cs_arg_names : list of str
+        Per-col-scale-term scaling vector argument names. Same role as
+        row-scale but for ``Mat_Mul(M, Diag(v_expr))``.
+
+    Returns
+    -------
+    str
+        Full function source (no decorator; the decorator is added
+        later by the module generator). Ready to be appended to the
+        generated module file.
+    """
+    # Build arg list: all dense vectors first, then per-term mapping
+    # arrays. No base variables needed — every term reads from a
+    # pre-computed dense vector.
+    args: List[str] = []
+    args.extend(diag_arg_names)
+    args.extend(rs_arg_names)
+    args.extend(cs_arg_names)
+
+    body_lines: List[str] = []
+    body_lines.append(f'    data = zeros({mapping.n_out})')
+
+    # Diag terms — ADDITIVE update at diagonal output positions. Using
+    # ``+=`` (not ``=``) is critical when the expression has multiple
+    # independent diag contributions on the same diagonal entries, e.g.
+    # ``Diag(A@x) + Diag(B@y)`` — both terms land on the same (i, i)
+    # positions and must accumulate. ``data`` starts at zero, so the
+    # additive update is also correct for the first term in isolation.
+    for ti, t in enumerate(mapping.diag_terms):
+        out_name = f'_sz_mb_diag_out_{ti}'
+        src_name = f'_sz_mb_diag_src_{ti}'
+        args.extend([out_name, src_name])
+        sign = t['sign']
+        u_name = diag_arg_names[ti]
+        body_lines.append(f'    for i in range({out_name}.shape[0]):')
+        if sign == 1:
+            body_lines.append(f'        data[{out_name}[i]] += {u_name}[{src_name}[i]]')
+        else:
+            body_lines.append(f'        data[{out_name}[i]] -= {u_name}[{src_name}[i]]')
+
+    # Row-scale terms: data[out[k]] += sign * rsv[src[k]] * mat_data[k]
+    for ti, t in enumerate(mapping.row_scale_terms):
+        out_name = f'_sz_mb_rs_out_{ti}'
+        src_name = f'_sz_mb_rs_src_{ti}'
+        dat_name = f'_sz_mb_rs_dat_{ti}'
+        args.extend([out_name, src_name, dat_name])
+        sign = t['sign']
+        rsv_name = rs_arg_names[ti]
+        body_lines.append(f'    for i in range({out_name}.shape[0]):')
+        if sign == 1:
+            body_lines.append(
+                f'        data[{out_name}[i]] += {rsv_name}[{src_name}[i]] * {dat_name}[i]')
+        else:
+            body_lines.append(
+                f'        data[{out_name}[i]] -= {rsv_name}[{src_name}[i]] * {dat_name}[i]')
+
+    # Col-scale terms: data[out[k]] += sign * csv[src[k]] * mat_data[k]
+    for ti, t in enumerate(mapping.col_scale_terms):
+        out_name = f'_sz_mb_cs_out_{ti}'
+        src_name = f'_sz_mb_cs_src_{ti}'
+        dat_name = f'_sz_mb_cs_dat_{ti}'
+        args.extend([out_name, src_name, dat_name])
+        sign = t['sign']
+        csv_name = cs_arg_names[ti]
+        body_lines.append(f'    for i in range({out_name}.shape[0]):')
+        if sign == 1:
+            body_lines.append(
+                f'        data[{out_name}[i]] += {csv_name}[{src_name}[i]] * {dat_name}[i]')
+        else:
+            body_lines.append(
+                f'        data[{out_name}[i]] -= {csv_name}[{src_name}[i]] * {dat_name}[i]')
+
+    body_lines.append('    return data')
+
+    signature = f'def {fn_name}(' + ', '.join(args) + '):'
+    return signature + '\n' + '\n'.join(body_lines) + '\n'
+
+
+def _var_base_name(var_expr: Expr) -> str:
+    """Return the base variable name for use in the function signature.
+
+    For ``iVar('e')`` → ``'e'``; for ``IdxVar('e[5:29]')`` → ``'e'``.
+    The full access expression (including slice) is produced separately
+    by :func:`_var_access_expr`.
+    """
+    if isinstance(var_expr, iVar):
+        return var_expr.name
+    if isinstance(var_expr, IdxVar):
+        return var_expr.name0
+    raise NotImplementedError(
+        f"var_expr inside Diag(...) must be a plain variable or slice, "
+        f"got {type(var_expr).__name__}: {var_expr}")
+
+
+def _var_access_expr(var_expr: Expr, var_arg_names: Dict[str, str]) -> str:
+    """Return the runtime access expression inside the @njit function body.
+
+    For ``iVar('e')`` → ``'e'``; for ``IdxVar('e[5:29]')`` → ``'e[5:29]'``
+    (a numpy slice). The base name is remapped through ``var_arg_names``
+    if the caller renamed arguments in the signature.
+    """
+    if isinstance(var_expr, iVar):
+        return var_arg_names.get(var_expr.name, var_expr.name)
+    if isinstance(var_expr, IdxVar):
+        base = var_arg_names.get(var_expr.name0, var_expr.name0)
+        idx = var_expr.index
+        if isinstance(idx, slice):
+            start = idx.start if idx.start is not None else ''
+            stop = idx.stop if idx.stop is not None else ''
+            step = f':{idx.step}' if idx.step is not None else ''
+            return f'{base}[{start}:{stop}{step}]'
+        if isinstance(idx, (int, np.integer)):
+            return f'{base}[{int(idx)}]'
+    raise NotImplementedError(
+        f"var_expr inside Diag(...) must be a plain variable or slice, "
+        f"got {type(var_expr).__name__}: {var_expr}")

--- a/Solverz/code_printer/python/module/mutable_mat_analyzer.py
+++ b/Solverz/code_printer/python/module/mutable_mat_analyzer.py
@@ -34,10 +34,10 @@ from __future__ import annotations
 from typing import Dict, List, Optional, Tuple
 
 import numpy as np
-from sympy import Add, Mul, S, Symbol, Expr, sympify, pycode
+from sympy import Add, Mul, S, Expr
 
 from Solverz.sym_algebra.functions import Diag, Mat_Mul
-from Solverz.sym_algebra.symbols import Para, iVar, IdxVar
+from Solverz.sym_algebra.symbols import Para
 
 
 class MutableMatBlockMapping:
@@ -399,41 +399,3 @@ def generate_block_function_code(fn_name: str,
     return signature + '\n' + '\n'.join(body_lines) + '\n'
 
 
-def _var_base_name(var_expr: Expr) -> str:
-    """Return the base variable name for use in the function signature.
-
-    For ``iVar('e')`` → ``'e'``; for ``IdxVar('e[5:29]')`` → ``'e'``.
-    The full access expression (including slice) is produced separately
-    by :func:`_var_access_expr`.
-    """
-    if isinstance(var_expr, iVar):
-        return var_expr.name
-    if isinstance(var_expr, IdxVar):
-        return var_expr.name0
-    raise NotImplementedError(
-        f"var_expr inside Diag(...) must be a plain variable or slice, "
-        f"got {type(var_expr).__name__}: {var_expr}")
-
-
-def _var_access_expr(var_expr: Expr, var_arg_names: Dict[str, str]) -> str:
-    """Return the runtime access expression inside the @njit function body.
-
-    For ``iVar('e')`` → ``'e'``; for ``IdxVar('e[5:29]')`` → ``'e[5:29]'``
-    (a numpy slice). The base name is remapped through ``var_arg_names``
-    if the caller renamed arguments in the signature.
-    """
-    if isinstance(var_expr, iVar):
-        return var_arg_names.get(var_expr.name, var_expr.name)
-    if isinstance(var_expr, IdxVar):
-        base = var_arg_names.get(var_expr.name0, var_expr.name0)
-        idx = var_expr.index
-        if isinstance(idx, slice):
-            start = idx.start if idx.start is not None else ''
-            stop = idx.stop if idx.stop is not None else ''
-            step = f':{idx.step}' if idx.step is not None else ''
-            return f'{base}[{start}:{stop}{step}]'
-        if isinstance(idx, (int, np.integer)):
-            return f'{base}[{int(idx)}]'
-    raise NotImplementedError(
-        f"var_expr inside Diag(...) must be a plain variable or slice, "
-        f"got {type(var_expr).__name__}: {var_expr}")

--- a/Solverz/code_printer/python/module/test/test_module_generator.py
+++ b/Solverz/code_printer/python/module/test/test_module_generator.py
@@ -145,7 +145,6 @@ expected_F_mat = """def F_(y_, p_):
     A_shape0 = p_["A_shape0"]
     b = p_["b"]
     c = p_["c"]
-    A = p_["A"]
     return inner_F(_F_, x, y, A_data, A_indices, A_indptr, A_shape0, b, c)
 """
 

--- a/Solverz/code_printer/python/module/test/test_module_printer.py
+++ b/Solverz/code_printer/python/module/test/test_module_printer.py
@@ -340,7 +340,6 @@ expected6 = """def F_(t, y_, p_):
     ax = p_["ax"]
     lam = p_["lam"]
     G6 = p_["G6"].get_v_t(t)
-    A = p_["A"]
     ax = ax_trigger_func(x)
     return inner_F(_F_, omega, delta, x, y, ax, lam, G6)
 """.strip()

--- a/Solverz/code_printer/python/module/test/test_module_printer.py
+++ b/Solverz/code_printer/python/module/test/test_module_printer.py
@@ -433,8 +433,8 @@ expected9 = """def inner_F0(delta, omega):
 expected10 = """def inner_F1(lam, x, y):
     return lam*y + x
 """.strip()
-expected11 = """def inner_F2(A, x):
-    return (A@x)
+expected11 = """def inner_F2(_sz_mm_0):
+    return _sz_mm_0
 """.strip()
 
 
@@ -450,8 +450,11 @@ def test_print_sub_inner_F():
     EQNs['b'] = Ode('b', x + y * lam, diff_var=x)
     EQNs['c'] = Eqn('c', Mat_Mul(A, x))
 
-    code_blocks, no_njit = print_sub_inner_F(EQNs)
+    code_blocks, precompute_info = print_sub_inner_F(EQNs)
     assert code_blocks[0] == expected9
     assert code_blocks[1] == expected10
     assert code_blocks[2] == expected11
-    assert no_njit == {2}  # EQNs['c'] uses Mat_Mul
+    # Mat_Mul equation got precompute info; others are empty
+    assert precompute_info[2]['matmuls']  # EQNs['c'] has one Mat_Mul
+    assert not precompute_info[0]['matmuls']  # non-Mat_Mul: empty
+    assert not precompute_info[1]['matmuls']

--- a/Solverz/code_printer/python/utilities.py
+++ b/Solverz/code_printer/python/utilities.py
@@ -181,6 +181,66 @@ def print_Hvp_prototype(eqs_type: str, func_name: str = 'Hvp_', nstep=0):
     return fp
 
 
+def extract_matmuls(expr):
+    """Extract Mat_Mul nodes from an expression and replace with placeholders.
+
+    Walks the expression tree, finds all Mat_Mul nodes, and replaces them with
+    iVar placeholders (_sz_mm_0, _sz_mm_1, ...). Handles nested Mat_Mul correctly —
+    inner Mat_Mul is extracted first, then the outer one uses the placeholder.
+
+    Short-circuit: if the expression contains no Mat_Mul, returns
+    ``(expr, [])`` unchanged without tree reconstruction, so non-matrix
+    equations are untouched.
+
+    Parameters
+    ----------
+    expr : sympy.Expr
+        Input expression that may contain Mat_Mul nodes.
+
+    Returns
+    -------
+    new_expr : sympy.Expr
+        Expression with Mat_Mul nodes replaced by iVar placeholders.
+    matmul_list : list of tuple
+        List of (placeholder_iVar, matrix_arg, operand_arg) triples. To
+        precompute: ``placeholder = matrix_arg @ operand_arg``.
+    """
+    # Fast path: no Mat_Mul means no transformation at all — preserves
+    # original expression and avoids reconstruction side effects.
+    if not (hasattr(expr, 'has') and expr.has(Mat_Mul)):
+        return expr, []
+
+    matmul_list = []
+    counter = [0]
+
+    def walk(e):
+        if isinstance(e, Mat_Mul):
+            # Recurse into args first (handle nested Mat_Mul)
+            new_args = [walk(a) for a in e.args]
+            name = f'_sz_mm_{counter[0]}'
+            counter[0] += 1
+            placeholder = iVar(name, internal_use=True)
+            if len(new_args) == 2:
+                matrix_arg = new_args[0]
+                operand_arg = new_args[1]
+            else:
+                # Mat_Mul(A, B, C, ...): fold into A @ (B @ C @ ...)
+                matrix_arg = new_args[0]
+                operand_arg = Mat_Mul(*new_args[1:])
+            matmul_list.append((placeholder, matrix_arg, operand_arg))
+            return placeholder
+        if hasattr(e, 'args') and len(e.args) > 0 and not e.is_Atom:
+            new_args = [walk(a) for a in e.args]
+            try:
+                return e.func(*new_args)
+            except Exception:
+                return e
+        return e
+
+    new_expr = walk(expr)
+    return new_expr, matmul_list
+
+
 def print_eqn_assignment(EQNs: Dict[str, Eqn],
                          EqnAddr: Address,
                          module_printer=False):

--- a/Solverz/equation/equations.py
+++ b/Solverz/equation/equations.py
@@ -89,37 +89,74 @@ class Equations:
         pass
 
     def _check_matmul_triggerable(self):
-        """Reject equations that mix ``Mat_Mul`` with triggerable or
-        time-series parameters.
+        """Reject Mat_Mul equations whose **matrix operand** is triggerable.
 
-        The mutable-matrix Jacobian pipeline bakes sparse matrix values
-        into the generated module at code-gen time. That is safe for
-        immutable parameters but catastrophically wrong if the same
-        parameter is updated at runtime via a trigger function or a
-        time series — the Jacobian would freeze on the initial values
-        while the residuals evolved. Rather than silently corrupting
-        results we reject the combination up front with a clear error.
+        The Layer-2 mutable-matrix Jacobian pipeline freezes a sparse
+        matrix's ``.data`` array into the generated scatter-add kernel
+        (the ``_sz_mb_{N}_rs_dat_*`` / ``_sz_mb_{N}_cs_dat_*`` cache in
+        ``mutable_mat_analyzer.py``). That is safe for immutable
+        matrices but silently wrong if the same matrix is mutated at
+        runtime via a trigger function — the Jacobian would keep using
+        the frozen values while the residual kept evolving with the
+        new ones.
+
+        The restriction is **specific to matrices flowing through
+        ``Mat_Mul``**. A triggerable vector or scalar multiplied into
+        the *result* of a ``Mat_Mul`` (or inside its vector operand)
+        is unaffected: the J_ wrapper reads the current parameter
+        value on every Newton step through ``p_[name]``, so the
+        bake-in logic never touches it. Only 2-D matrix operands of
+        ``Mat_Mul`` are rejected here.
+
+        The walk mirrors :meth:`_warn_dense_matmul_params` — for every
+        ``Mat_Mul`` node in every mixed-matrix-vector equation, inspect
+        ``arg.free_symbols`` for any 2-D triggerable ``Para``. Dense
+        2-D params reach the ``MutableMatJacDataModule`` fallback path
+        which re-evaluates the full sparse expression on every call
+        and is therefore triggerable-safe — the narrow check skips
+        them (they already get a performance warning in
+        :meth:`_warn_dense_matmul_params`).
         """
         for eqn_name, eqn in self.EQNs.items():
             if not eqn.mixed_matrix_vector:
                 continue
-            for sym_name in eqn.SYMBOLS.keys():
-                if sym_name not in self.PARAM:
-                    continue
-                p = self.PARAM[sym_name]
-                is_ts = isinstance(p, TimeSeriesParam)
-                if is_ts or getattr(p, 'triggerable', False):
-                    kind = 'time-series' if is_ts else 'triggerable'
-                    raise NotImplementedError(
-                        f"Equation {eqn_name!r} uses ``Mat_Mul`` together with "
-                        f"{kind} parameter {sym_name!r}. This combination is "
-                        f"not currently supported because the Mat_Mul code "
-                        f"generator assumes matrix parameters are immutable "
-                        f"after ``create_instance()``. Please either (a) make "
-                        f"{sym_name!r} a plain Param without ``triggerable`` / "
-                        f"TimeSeriesParam wrapping, or (b) remove Mat_Mul "
-                        f"from this equation."
-                    )
+            for mm in eqn.RHS.atoms(Mat_Mul):
+                for arg in mm.args:
+                    matrix_paras = {
+                        s for s in arg.free_symbols
+                        if isinstance(s, Para) and s.dim == 2
+                    }
+                    for sym in matrix_paras:
+                        if sym.name not in self.PARAM:
+                            continue
+                        p = self.PARAM[sym.name]
+                        # Dense dim=2 → fallback path, safe (and already
+                        # warned about elsewhere). Only sparse 2-D
+                        # matrices flow through the scatter-add cache.
+                        if not getattr(p, 'sparse', False):
+                            continue
+                        is_ts = isinstance(p, TimeSeriesParam)
+                        is_trig = getattr(p, 'triggerable', False)
+                        if not (is_ts or is_trig):
+                            continue
+                        kind = 'time-series' if is_ts else 'triggerable'
+                        raise NotImplementedError(
+                            f"Equation {eqn_name!r} uses {kind} 2-D sparse "
+                            f"parameter {sym.name!r} as a ``Mat_Mul`` matrix "
+                            f"operand. ``Mat_Mul`` bakes the sparse matrix "
+                            f"``.data`` array into the generated scatter-add "
+                            f"Jacobian kernel at model-build time; a "
+                            f"{kind} update at runtime would silently be "
+                            f"ignored and the Jacobian would freeze on the "
+                            f"initial matrix values while the residual kept "
+                            f"evolving — producing wrong Newton steps. If "
+                            f"{sym.name!r} must change at runtime, split the "
+                            f"residual so that the ``Mat_Mul({sym.name}, ..)``"
+                            f" term lives in its own equation and rewrite "
+                            f"that equation in explicit elementwise form "
+                            f"(one scalar ``Eqn`` per row) instead of using "
+                            f"``Mat_Mul``."
+                        )
 
     def _warn_dense_matmul_params(self):
         """Warn when a dense ``dim=2`` parameter is used inside a
@@ -175,19 +212,37 @@ class Equations:
             args = self.obtain_eqn_args(DiffVarEqn, y, 0)
             DiffVarValue = Array(DiffVarEqn.NUM_EQN(*args), dim=1)
 
-            # Mutable matrix Jacobian detection (contains both Mat_Mul and
-            # Diag in a matrix-valued derivative). For such blocks we MUST
-            # use sps.diags (not np.diagflat) so that Value0's sparsity
-            # pattern captures ALL structural non-zeros (union of each
-            # term's pattern), independently of the numerical values at y0.
-            # This guarantees Value0.tocsc().data order == runtime
-            # .tocsc().data order, so the runtime can do O(nnz) direct
-            # data copy without any fancy indexing.
-            is_mutable_matrix_block = (
-                DeriExpr.has(Mat_Mul) and DeriExpr.has(Diag)
-                and not isinstance(DeriExpr, Para)
-                and not isinstance(-DeriExpr, Para)
+            # Mutable-matrix-block detection. This predicate MUST match
+            # ``JacBlock.is_mutable_matrix`` in ``jac.py:167-169`` exactly
+            # — FormJac picks Value0 here and JacBlock picks the
+            # downstream codegen path from the *same* flag, so any
+            # divergence between the two locations would produce blocks
+            # whose Value0 sparsity pattern disagreed with the kernel the
+            # code generator then emitted (e.g. a flat-start ``Diag(x)``
+            # Value0 would collapse to empty while the scatter-add loop
+            # expected a full diagonal).
+            #
+            # Criterion (same as JacBlock): the derivative is
+            # matrix-valued AND its symbolic form is not a plain
+            # ``Para`` / ``-Para``. We probe "matrix-valued" from the
+            # already-evaluated ``fy[3]`` (either a ``csc_array`` from
+            # a sparse expression or an ndarray with ``ndim == 2`` from
+            # a dense one).
+            fy_value = fy[3]
+            fy_is_matrix = (
+                isinstance(fy_value, csc_array)
+                or (isinstance(fy_value, np.ndarray) and fy_value.ndim == 2)
             )
+            deri_is_para = (isinstance(DeriExpr, Para)
+                            or isinstance(-DeriExpr, Para))
+            is_mutable_matrix_block = fy_is_matrix and not deri_is_para
+            # For such blocks we MUST use sps.diags (not np.diagflat) so
+            # that Value0's sparsity pattern captures ALL structural
+            # non-zeros (union of each term's pattern), independently of
+            # the numerical values at y0. This guarantees
+            # Value0.tocsc().data order == runtime .tocsc().data order,
+            # so the runtime can do O(nnz) direct data copy without any
+            # fancy indexing.
             if is_mutable_matrix_block:
                 sparse_expr = DeriExpr.replace(Diag, SpDiag)
                 sparse_eqn = Eqn('_MutMatJb_' + EqnName + '_' + DiffVar.name,

--- a/Solverz/equation/equations.py
+++ b/Solverz/equation/equations.py
@@ -12,9 +12,9 @@ from scipy.sparse import csc_array, coo_array
 # from cvxopt import spmatrix, matrix
 
 from Solverz.equation.eqn import Eqn, Ode, EqnDiff
-from Solverz.equation.param import ParamBase, Param, IdxParam
+from Solverz.equation.param import ParamBase, Param, IdxParam, TimeSeriesParam
 from Solverz.sym_algebra.symbols import iVar, idx, IdxVar, Para, iAliasVar
-from Solverz.sym_algebra.functions import Slice
+from Solverz.sym_algebra.functions import Slice, Mat_Mul, Diag, SpDiag
 from Solverz.variable.variables import Vars
 from Solverz.utilities.address import Address, combine_Address
 from Solverz.utilities.type_checker import is_integer
@@ -88,10 +88,78 @@ class Equations:
            var_list: List[str] = None) -> List[Tuple[str, str, EqnDiff, np.ndarray]]:
         pass
 
+    def _check_matmul_triggerable(self):
+        """Reject equations that mix ``Mat_Mul`` with triggerable or
+        time-series parameters.
+
+        The mutable-matrix Jacobian pipeline bakes sparse matrix values
+        into the generated module at code-gen time. That is safe for
+        immutable parameters but catastrophically wrong if the same
+        parameter is updated at runtime via a trigger function or a
+        time series — the Jacobian would freeze on the initial values
+        while the residuals evolved. Rather than silently corrupting
+        results we reject the combination up front with a clear error.
+        """
+        for eqn_name, eqn in self.EQNs.items():
+            if not eqn.mixed_matrix_vector:
+                continue
+            for sym_name in eqn.SYMBOLS.keys():
+                if sym_name not in self.PARAM:
+                    continue
+                p = self.PARAM[sym_name]
+                is_ts = isinstance(p, TimeSeriesParam)
+                if is_ts or getattr(p, 'triggerable', False):
+                    kind = 'time-series' if is_ts else 'triggerable'
+                    raise NotImplementedError(
+                        f"Equation {eqn_name!r} uses ``Mat_Mul`` together with "
+                        f"{kind} parameter {sym_name!r}. This combination is "
+                        f"not currently supported because the Mat_Mul code "
+                        f"generator assumes matrix parameters are immutable "
+                        f"after ``create_instance()``. Please either (a) make "
+                        f"{sym_name!r} a plain Param without ``triggerable`` / "
+                        f"TimeSeriesParam wrapping, or (b) remove Mat_Mul "
+                        f"from this equation."
+                    )
+
+    def _warn_dense_matmul_params(self):
+        """Warn when a dense ``dim=2`` parameter is used inside a
+        ``Mat_Mul``. Such parameters fall back to the slower
+        scipy/ndarray fancy-indexing path and do not benefit from the
+        vectorised mutable-matrix Jacobian code. Each offending param is
+        warned about exactly once per system.
+        """
+        warned = set()
+        for eqn_name, eqn in self.EQNs.items():
+            if not eqn.mixed_matrix_vector:
+                continue
+            for mm in eqn.RHS.atoms(Mat_Mul):
+                for arg in mm.args:
+                    free_paras = {s for s in arg.free_symbols if isinstance(s, Para)}
+                    for sym in free_paras:
+                        if sym.name not in self.PARAM:
+                            continue
+                        p = self.PARAM[sym.name]
+                        if p.dim == 2 and not p.sparse and sym.name not in warned:
+                            warnings.warn(
+                                f"Parameter {sym.name!r} is a dense 2-D "
+                                f"``Param(..., dim=2, sparse=False)`` used "
+                                f"inside ``Mat_Mul``. Dense matrices bypass "
+                                f"the vectorised mutable-matrix Jacobian "
+                                f"fast path and fall back to a slower "
+                                f"scipy/ndarray indexing path. Declare "
+                                f"{sym.name!r} with ``sparse=True`` for "
+                                f"substantially better performance.",
+                                UserWarning, stacklevel=3
+                            )
+                            warned.add(sym.name)
+
     def FormJac(self,
                 y
                 ):
         self.assign_eqn_var_address(y)
+
+        self._check_matmul_triggerable()
+        self._warn_dense_matmul_params()
 
         Fy_list = self.Fy(y, self.a.object_list, self.var_address.object_list)
 
@@ -107,11 +175,46 @@ class Equations:
             args = self.obtain_eqn_args(DiffVarEqn, y, 0)
             DiffVarValue = Array(DiffVarEqn.NUM_EQN(*args), dim=1)
 
-            # The value of deri can be either matrix, vector, or scalar(number). We cannot reshape it.
-            if isinstance(fy[3], csc_array):
-                Value0 = fy[3]
+            # Mutable matrix Jacobian detection (contains both Mat_Mul and
+            # Diag in a matrix-valued derivative). For such blocks we MUST
+            # use sps.diags (not np.diagflat) so that Value0's sparsity
+            # pattern captures ALL structural non-zeros (union of each
+            # term's pattern), independently of the numerical values at y0.
+            # This guarantees Value0.tocsc().data order == runtime
+            # .tocsc().data order, so the runtime can do O(nnz) direct
+            # data copy without any fancy indexing.
+            is_mutable_matrix_block = (
+                DeriExpr.has(Mat_Mul) and DeriExpr.has(Diag)
+                and not isinstance(DeriExpr, Para)
+                and not isinstance(-DeriExpr, Para)
+            )
+            if is_mutable_matrix_block:
+                sparse_expr = DeriExpr.replace(Diag, SpDiag)
+                sparse_eqn = Eqn('_MutMatJb_' + EqnName + '_' + DiffVar.name,
+                                 sparse_expr)
+                sparse_args = self.obtain_eqn_args(sparse_eqn, y, 0)
+                # Perturb variable values with distinct non-zero samples so
+                # that ``sps.diags(v) @ M`` doesn't collapse to the empty
+                # matrix when v happens to be zero at y0 (as in flat start).
+                # Value0 is only used for sparsity-pattern tracking — the
+                # data is overwritten at the first J_() call — so the
+                # perturbation is harmless.
+                rng = np.random.default_rng(seed=20260412)
+                perturbed_args = []
+                for symbol, arg in zip(sparse_eqn.SYMBOLS.values(), sparse_args):
+                    if symbol.name in y.var_list:
+                        perturbed_args.append(rng.random(arg.shape) + 1.0)
+                    else:
+                        perturbed_args.append(arg)
+                Value0 = sparse_eqn.NUM_EQN(*perturbed_args)
+                if not isinstance(Value0, csc_array):
+                    Value0 = csc_array(Value0)
             else:
-                Value0 = np.array(fy[3])
+                # The value of deri can be either matrix, vector, or scalar.
+                if isinstance(fy[3], csc_array):
+                    Value0 = fy[3]
+                else:
+                    Value0 = np.array(fy[3])
 
             jb = JacBlock(EqnName,
                           EqnAddr,

--- a/Solverz/equation/equations.py
+++ b/Solverz/equation/equations.py
@@ -88,75 +88,48 @@ class Equations:
            var_list: List[str] = None) -> List[Tuple[str, str, EqnDiff, np.ndarray]]:
         pass
 
-    def _check_matmul_triggerable(self):
-        """Reject Mat_Mul equations whose **matrix operand** is triggerable.
+    def _check_no_timevar_sparse_matrices(self):
+        """Backstop check: reject any time-varying sparse ``dim=2``
+        ``Param`` in the equation system.
 
-        The Layer-2 mutable-matrix Jacobian pipeline freezes a sparse
-        matrix's ``.data`` array into the generated scatter-add kernel
-        (the ``_sz_mb_{N}_rs_dat_*`` / ``_sz_mb_{N}_cs_dat_*`` cache in
-        ``mutable_mat_analyzer.py``). That is safe for immutable
-        matrices but silently wrong if the same matrix is mutated at
-        runtime via a trigger function — the Jacobian would keep using
-        the frozen values while the residual kept evolving with the
-        new ones.
-
-        The restriction is **specific to matrices flowing through
-        ``Mat_Mul``**. A triggerable vector or scalar multiplied into
-        the *result* of a ``Mat_Mul`` (or inside its vector operand)
-        is unaffected: the J_ wrapper reads the current parameter
-        value on every Newton step through ``p_[name]``, so the
-        bake-in logic never touches it. Only 2-D matrix operands of
-        ``Mat_Mul`` are rejected here.
-
-        The walk mirrors :meth:`_warn_dense_matmul_params` — for every
-        ``Mat_Mul`` node in every mixed-matrix-vector equation, inspect
-        ``arg.free_symbols`` for any 2-D triggerable ``Para``. Dense
-        2-D params reach the ``MutableMatJacDataModule`` fallback path
-        which re-evaluates the full sparse expression on every call
-        and is therefore triggerable-safe — the narrow check skips
-        them (they already get a performance warning in
-        :meth:`_warn_dense_matmul_params`).
+        The primary defence lives in :class:`ParamBase.__init__` /
+        :class:`TimeSeriesParam.__init__`, which reject the offending
+        shape at the point of construction. This method re-checks at
+        ``FormJac`` time to cover the unusual paths where a Param is
+        built via ``__new__`` without going through ``__init__``, or
+        where its ``triggerable`` flag is set after construction. A
+        wrong model that slips past both defences would silently
+        produce incorrect Jacobians because every downstream code
+        path (the legacy ``MatVecMul`` CSC decomposition, the 0.8.1
+        ``Mat_Mul`` ``SolCF.csc_matvec`` fast path, and the
+        mutable-matrix Jacobian scatter-add kernel) caches the sparse
+        matrix's ``.data`` / ``.indices`` / ``.indptr`` arrays at
+        model-build time.
         """
-        for eqn_name, eqn in self.EQNs.items():
-            if not eqn.mixed_matrix_vector:
+        for name, p in self.PARAM.items():
+            if not (getattr(p, 'dim', 0) == 2
+                    and getattr(p, 'sparse', False)):
                 continue
-            for mm in eqn.RHS.atoms(Mat_Mul):
-                for arg in mm.args:
-                    matrix_paras = {
-                        s for s in arg.free_symbols
-                        if isinstance(s, Para) and s.dim == 2
-                    }
-                    for sym in matrix_paras:
-                        if sym.name not in self.PARAM:
-                            continue
-                        p = self.PARAM[sym.name]
-                        # Dense dim=2 → fallback path, safe (and already
-                        # warned about elsewhere). Only sparse 2-D
-                        # matrices flow through the scatter-add cache.
-                        if not getattr(p, 'sparse', False):
-                            continue
-                        is_ts = isinstance(p, TimeSeriesParam)
-                        is_trig = getattr(p, 'triggerable', False)
-                        if not (is_ts or is_trig):
-                            continue
-                        kind = 'time-series' if is_ts else 'triggerable'
-                        raise NotImplementedError(
-                            f"Equation {eqn_name!r} uses {kind} 2-D sparse "
-                            f"parameter {sym.name!r} as a ``Mat_Mul`` matrix "
-                            f"operand. ``Mat_Mul`` bakes the sparse matrix "
-                            f"``.data`` array into the generated scatter-add "
-                            f"Jacobian kernel at model-build time; a "
-                            f"{kind} update at runtime would silently be "
-                            f"ignored and the Jacobian would freeze on the "
-                            f"initial matrix values while the residual kept "
-                            f"evolving — producing wrong Newton steps. If "
-                            f"{sym.name!r} must change at runtime, split the "
-                            f"residual so that the ``Mat_Mul({sym.name}, ..)``"
-                            f" term lives in its own equation and rewrite "
-                            f"that equation in explicit elementwise form "
-                            f"(one scalar ``Eqn`` per row) instead of using "
-                            f"``Mat_Mul``."
-                        )
+            is_ts = isinstance(p, TimeSeriesParam)
+            is_trig = getattr(p, 'triggerable', False)
+            if not (is_ts or is_trig):
+                continue
+            kind = 'time-series' if is_ts else 'triggerable'
+            raise NotImplementedError(
+                f"Parameter {name!r} is a {kind} sparse ``dim=2`` "
+                f"parameter. Time-varying sparse matrices are not "
+                f"supported by Solverz because the code generator "
+                f"caches the matrix's CSC fields at model-build "
+                f"time; a runtime {kind} update would silently be "
+                f"ignored by every downstream consumer (legacy "
+                f"``MatVecMul``, ``Mat_Mul`` fast path, and the "
+                f"mutable-matrix Jacobian scatter-add). Rewrite the "
+                f"equation in explicit element-wise form (one scalar "
+                f"``Eqn`` per row) or use a dense ``dim=2`` "
+                f"parameter (``sparse=False``) — the fallback scipy "
+                f"path re-evaluates the full expression on every "
+                f"call and tolerates updates."
+            )
 
     def _warn_dense_matmul_params(self):
         """Warn when a dense ``dim=2`` parameter is used inside a
@@ -195,7 +168,7 @@ class Equations:
                 ):
         self.assign_eqn_var_address(y)
 
-        self._check_matmul_triggerable()
+        self._check_no_timevar_sparse_matrices()
         self._warn_dense_matmul_params()
 
         Fy_list = self.Fy(y, self.a.object_list, self.var_address.object_list)

--- a/Solverz/equation/param.py
+++ b/Solverz/equation/param.py
@@ -20,6 +20,39 @@ class ParamBase:
                  dtype=float,
                  sparse=False,
                  is_alias=False):
+        # Time-varying sparse 2-D Params are unsupported by design.
+        # Solverz's code generation — both the legacy ``MatVecMul``
+        # path and the 0.8.1 ``Mat_Mul`` ``SolCF.csc_matvec`` fast
+        # path — freezes a sparse ``dim=2`` param's CSC
+        # decomposition (``<name>_data`` / ``_indices`` / ``_indptr``
+        # / ``_shape0``) at model-build time. The mutable-matrix
+        # Jacobian kernel caches its ``.data`` inside @njit scatter-
+        # add loops, also at model-build time. A runtime trigger
+        # update would silently be ignored by every downstream
+        # consumer and produce wrong Newton steps.
+        #
+        # Reject at construction time so the error fires at the line
+        # where the user wrote the offending declaration, rather
+        # than deep inside ``FormJac``. ``TimeSeriesParam`` has the
+        # same restriction (checked in its own ``__init__`` below,
+        # since it always passes ``triggerable=False`` to this
+        # constructor).
+        if sparse and dim == 2 and triggerable:
+            raise NotImplementedError(
+                f"Parameter {name!r}: a sparse 2-D ``Param`` cannot "
+                f"be declared ``triggerable=True``. Time-varying "
+                f"sparse matrices are unsupported because Solverz's "
+                f"code generation caches the matrix's CSC fields at "
+                f"model-build time; a runtime trigger update would "
+                f"silently be ignored. If you need a matrix whose "
+                f"values change at runtime, rewrite the equation in "
+                f"explicit element-wise form (one scalar ``Eqn`` per "
+                f"row) using the per-row coefficients as 1-D "
+                f"``Param`` or ``TimeSeriesParam`` instances, or use "
+                f"a dense ``dim=2`` parameter (``sparse=False``) — "
+                f"the fallback scipy path re-evaluates the full "
+                f"expression on every call and tolerates updates."
+            )
         self.name = name
         self.triggerable = triggerable
         self.trigger_var = [trigger_var] if isinstance(trigger_var, str) else trigger_var
@@ -113,6 +146,23 @@ class TimeSeriesParam(Param):
                  dtype=float,
                  sparse=False
                  ):
+        # ``TimeSeriesParam`` is the other class of time-varying
+        # parameter Solverz supports. The same immutability
+        # constraint as in ``ParamBase.__init__`` applies to sparse
+        # 2-D matrices: the generated module caches CSC fields at
+        # build time and ``get_v_t(t)`` updates would be invisible
+        # to the downstream fast path.
+        if sparse and dim == 2:
+            raise NotImplementedError(
+                f"Parameter {name!r}: a sparse 2-D "
+                f"``TimeSeriesParam`` is not supported. Solverz's "
+                f"code generation caches the matrix's CSC fields at "
+                f"model-build time; a time-series update at runtime "
+                f"would silently be ignored. Use a 1-D "
+                f"``TimeSeriesParam`` (scale / per-row coefficients) "
+                f"and assemble the matrix element-wise, or use a "
+                f"dense ``dim=2`` parameter (``sparse=False``)."
+            )
         if value is None:
             value = v_series[0]
         super().__init__(name,

--- a/Solverz/equation/test/test_Param.py
+++ b/Solverz/equation/test/test_Param.py
@@ -64,12 +64,23 @@ def test_Param():
     except ValueError as e:
         assert e.args[0] == 'Incompatible length between value series and time series!'
 
-    G = TimeSeriesParam(name='G',
+    # Sparse 2-D ``TimeSeriesParam`` used to be silently constructable
+    # even though the downstream code generator (both the legacy
+    # ``MatVecMul`` path and the 0.8.1 ``Mat_Mul`` fast path) snapshots
+    # the matrix's CSC decomposition at ``model.create_instance``
+    # time — any runtime ``get_v_t(t)`` update to a specific index
+    # would never propagate into the cached ``<name>_data`` / etc.
+    # arrays that the generated code actually reads. Construction is
+    # now rejected up front.
+    import pytest
+    with pytest.raises(NotImplementedError,
+                       match=r"sparse 2-D ``TimeSeriesParam``"):
+        TimeSeriesParam(name='G',
                         v_series=[2, 10000, 10000, 2, 2],
                         time_series=[0, 0.002, 0.03, 0.032, 10],
-                        value=np.array([[1, 0, 3], [0, 0.1, -0.4], [1.2, -np.pi, 0]]),
+                        value=np.array([[1, 0, 3],
+                                        [0, 0.1, -0.4],
+                                        [1.2, -np.pi, 0]]),
                         index=(1, 1),
                         dim=2,
                         sparse=True)
-    assert (G.get_v_t(0.001).toarray().__str__() ==
-            '[[ 1.00000000e+00  0.00000000e+00  3.00000000e+00]\n [ 0.00000000e+00  5.00100000e+03 -4.00000000e-01]\n [ 1.20000000e+00 -3.14159265e+00  0.00000000e+00]]')

--- a/Solverz/model/basic.py
+++ b/Solverz/model/basic.py
@@ -45,7 +45,15 @@ class Model:
                 self.var_dict[key] = value
             elif isinstance(value, ParamBase):
                 self.param_dict[key] = value
-                if value.dim == 2 or value.sparse:
+                # Only **sparse** dim=2 parameters get decomposed into
+                # their CSC components (``_data``, ``_indices``,
+                # ``_indptr``, ``_shape0``) for legacy backends that
+                # consume these flat arrays. Dense ``dim=2`` parameters
+                # have no ``.indices`` / ``.indptr`` — attempting to
+                # decompose them yields a ``memoryview`` (from
+                # ``ndarray.data``) which then crashes deep in
+                # ``Array``.
+                if value.sparse and value.dim == 2:
                     self.param_dict[key + '_data'] = Param(key + '_data', value.v.data)
                     self.param_dict[key + '_indices'] = Param(key + '_indices', value.v.indices, dtype=int)
                     self.param_dict[key + '_indptr'] = Param(key + '_indptr', value.v.indptr, dtype=int)

--- a/Solverz/num_api/custom_function.py
+++ b/Solverz/num_api/custom_function.py
@@ -5,8 +5,35 @@ from functools import reduce
 import warnings
 import numpy as np
 from numpy import linalg
-from scipy.sparse import diags, csc_array, coo_array, linalg as sla
+from scipy.sparse import diags, csc_array, coo_array, linalg as sla, issparse
 from numba import njit
+
+
+def mutable_mat_fallback_extract(expr_value, rows, cols):
+    """Fallback index extraction for a mutable-matrix Jacobian block.
+
+    ``expr_value`` may be either a scipy.sparse matrix/array (common
+    case: the expression contains ``Mat_Mul`` of sparse params) or a
+    dense ``numpy.ndarray`` (common case: the expression mixes in a
+    ``dim=2 sparse=False`` parameter). We dispatch on type so that the
+    generated J_ wrapper evaluates the expression once and indexes it
+    correctly regardless of which shape came out.
+
+    Parameters
+    ----------
+    expr_value : scipy.sparse matrix/array or numpy.ndarray
+        The evaluated mutable-matrix block expression.
+    rows, cols : sequence of int
+        Row / column indices into ``expr_value``; same length.
+
+    Returns
+    -------
+    numpy.ndarray
+        1-D array of length ``len(rows)`` with ``expr_value[r_i, c_i]``.
+    """
+    if issparse(expr_value):
+        return np.asarray(expr_value.tocsr()[rows, cols]).ravel()
+    return np.asarray(expr_value)[rows, cols]
 
 
 # from cvxopt.umfpack import linsolve

--- a/Solverz/sym_algebra/functions.py
+++ b/Solverz/sym_algebra/functions.py
@@ -163,6 +163,40 @@ class Diag(MatrixFunction):
         return r'diag(' + printer._print(self.args[0], **kwargs) + r')'
 
 
+class SpDiag(MatrixFunction):
+    """Sparse-format diagonal matrix constructor.
+
+    Same semantics as ``Diag`` but prints to ``sps.diags`` (scipy.sparse)
+    instead of ``np.diagflat`` (dense). Used by the module printer to compute
+    mutable matrix Jacobian blocks with sparse ops at both init time
+    (``Value0``) and runtime, so the sparsity patterns match exactly.
+
+    Do not construct this directly — it is created via
+    ``expr.replace(Diag, SpDiag)`` in mutable-matrix code generation.
+    """
+
+    @classmethod
+    def eval(cls, *args):
+        if len(args) != 1:
+            raise TypeError(f"SpDiag takes 1 positional argument but {len(args)} were given!")
+        if args[0] == S.Zero:
+            return 0
+        elif isinstance(args[0], Number):
+            return args[0]
+
+    def _sympystr(self, printer, **kwargs):
+        return 'sp_diag({operand})'.format(operand=printer._print(self.args[0]))
+
+    def _numpycode(self, printer, **kwargs):
+        return r'sps.diags(' + printer._print(self.args[0], **kwargs) + r')'
+
+    def _lambdacode(self, printer, **kwargs):
+        return self._numpycode(printer, **kwargs)
+
+    def _pythoncode(self, printer, **kwargs):
+        return self._numpycode(printer, **kwargs)
+
+
 # %% Univariate func
 @VarParser
 class UniVarFunc(Function):

--- a/Solverz/sym_algebra/symbols.py
+++ b/Solverz/sym_algebra/symbols.py
@@ -70,6 +70,17 @@ Solverz_internal_name = ['y_', 'F_', 'F__' 'p_', 'J_', 'p__'
                          'row', 'col', 'data', '_F_', 'data_', 'Hvp_', 'v_', 'row_hvp', 'col_hvp', 'data_hvp',
                          '_data_', '_data_hvp']
 
+# Reserved *prefixes* for code-generator internal helper identifiers.
+# Any user symbol whose name starts with one of these is rejected at
+# model-build time so the code generator can emit unlimited helpers of
+# the form ``<prefix><int>`` without risk of shadowing a user symbol.
+#
+# - ``_sz_mm_`` : Mat_Mul precompute placeholders in the F_/J_ wrapper
+#                 (e.g. ``_sz_mm_0 = G @ e``).
+# - ``_sz_mb_`` : mutable-matrix Jacobian block helpers (diag inners,
+#                 row/col-scale scaling vectors, mapping arrays).
+Solverz_internal_prefixes = ['_sz_mm_', '_sz_mb_']
+
 
 class SolSymBasic(Symbol):
     """
@@ -83,6 +94,15 @@ class SolSymBasic(Symbol):
             if not internal_use:
                 raise ValueError(
                     f"Solverz built-in name {name}, cannot be used as variable name.")
+        if not internal_use:
+            for prefix in Solverz_internal_prefixes:
+                if name.startswith(prefix):
+                    raise ValueError(
+                        f"Symbol name {name!r} starts with Solverz-reserved "
+                        f"internal prefix {prefix!r}. This prefix is used by "
+                        f"the code generator for Mat_Mul / mutable-matrix "
+                        f"Jacobian helper names and cannot be used for user "
+                        f"variables or parameters.")
         obj = Symbol.__new__(cls, f'{name}')
         obj.name = f'{name}'
         obj.dim = dim

--- a/docs/src/matrix_calculus.md
+++ b/docs/src/matrix_calculus.md
@@ -310,7 +310,7 @@ pattern or its `.data` values as a constant; mutating them in-place
 will silently corrupt results without raising any error.
 ```
 
-### Layer 1 — Precompute `Mat_Mul` in the `F_` wrapper
+### Layer 1 — `Mat_Mul` precomputes as ``@njit`` CSC matvec
 
 The code printer walks every residual RHS looking for `Mat_Mul(A, v)`
 sub-trees, where `A` is a sparse parameter and `v` is any vector-valued
@@ -327,34 +327,51 @@ expression (a variable, a slice, or a larger expression). It performs
    into a single placeholder. The power-flow example below computes
    `G_nr @ e` once even though both the P-balance and Q-balance
    residuals reference it.
-3. **Emit precompute statements in the wrapper.** Each placeholder gets
-   one line of the form `_sz_mm_N = A @ operand` inserted at the top of
-   the `F_()` function body, *outside* the Numba-compiled inner
-   functions.
+3. **Classify each placeholder.** The classifier (implemented in
+   `_is_csc_matvec_fast_path` in
+   `Solverz/code_printer/python/module/module_printer.py`) decides
+   whether the precompute can go on the **fast path** (matrix is a
+   plain sparse `dim=2` `Para`) or the **fallback path** (anything
+   else: `-Para`, nested `Mat_Mul`, dense `dim=2` matrices, or a
+   matrix expression).
 
-The runtime effect: the *only* scipy.sparse matrix-vector product that
-happens inside a Newton step is the one at the very top of `F_()`.
-Every downstream computation (`inner_F`, `inner_F0`, `inner_F1`, …)
-receives `_sz_mm_N` as a plain dense numpy array and can run under
-`@njit(cache=True)`:
+**Fast path** — the matvec is computed **inside `inner_F`** via the
+existing `SolCF.csc_matvec` Numba helper
+(`Solverz/num_api/custom_function.py`). Each sparse dim=2 `Param` is
+already decomposed at model-build time into its CSC flat arrays
+(`A_data` / `A_indices` / `A_indptr` / `A_shape0`) by
+`Solverz/model/basic.py`; these flat arrays flow through
+`param_list` to `inner_F` as ordinary numpy arrays, and `inner_F`
+issues a `SolCF.csc_matvec(A_data, A_indices, A_indptr, A_shape0,
+operand)` call per placeholder. The wrapper `F_()` does not load the
+sparse matrix object `A` at all — the whole matvec lives in Numba
+land and pays zero scipy dispatch cost:
 
 ```python
 def F_(y_, p_):
     e = y_[0:29]
     f = y_[29:58]
-    G_nr = p_["G_nr"]              # csc_array, scipy.sparse
-    B_nr = p_["B_nr"]
-    _sz_mm_0 = (G_nr @ e)          # ← precomputed, one scipy SpMV
-    _sz_mm_1 = (B_nr @ f)          # ← dedup: B_nr@f appears in 2 equations
-    _sz_mm_2 = (B_nr @ e)
-    _sz_mm_3 = (G_nr @ f)
+    G_nr_data = p_["G_nr_data"]
+    G_nr_indices = p_["G_nr_indices"]
+    G_nr_indptr = p_["G_nr_indptr"]
+    G_nr_shape0 = p_["G_nr_shape0"]
+    B_nr_data = p_["B_nr_data"]
+    ...   # dense vector params follow
     return inner_F(_F_, e, f, p_ref, q_ref,
-                   _sz_mm_0, _sz_mm_1, _sz_mm_2, _sz_mm_3, ...)
+                   G_nr_data, G_nr_indices, G_nr_indptr, G_nr_shape0,
+                   B_nr_data, B_nr_indices, B_nr_indptr, B_nr_shape0,
+                   ...)
 
 @njit(cache=True)
 def inner_F(_F_, e, f, p_ref, q_ref,
-            _sz_mm_0, _sz_mm_1, _sz_mm_2, _sz_mm_3, ...):
-    _F_[0:29] = inner_F0(e, f, p_ref, _sz_mm_0, _sz_mm_1, _sz_mm_2, _sz_mm_3)
+            G_nr_data, G_nr_indices, G_nr_indptr, G_nr_shape0,
+            B_nr_data, B_nr_indices, B_nr_indptr, B_nr_shape0, ...):
+    # Fast-path matvecs: all inside @njit, no scipy dispatch.
+    _sz_mm_0 = SolCF.csc_matvec(G_nr_data, G_nr_indices, G_nr_indptr, G_nr_shape0, e)
+    _sz_mm_1 = SolCF.csc_matvec(B_nr_data, B_nr_indices, B_nr_indptr, B_nr_shape0, f)
+    _sz_mm_2 = SolCF.csc_matvec(B_nr_data, B_nr_indices, B_nr_indptr, B_nr_shape0, e)
+    _sz_mm_3 = SolCF.csc_matvec(G_nr_data, G_nr_indices, G_nr_indptr, G_nr_shape0, f)
+    _F_[0:29] = inner_F0(e, f, p_ref, q_ref, _sz_mm_0, _sz_mm_1, _sz_mm_2, _sz_mm_3)
     _F_[29:53] = inner_F1(...)
     return _F_
 
@@ -363,12 +380,120 @@ def inner_F0(e, f, p_ref, q_ref, _sz_mm_0, _sz_mm_1, _sz_mm_2, _sz_mm_3):
     return e * (p_ref - _sz_mm_1 + _sz_mm_0) + f * (q_ref + _sz_mm_2 + _sz_mm_3) - Pinj
 ```
 
-Why this matters: scipy.sparse matrix-vector products are already
-implemented in C and fairly fast, but *constructing intermediate sparse
-matrices* (e.g. `diag(e) @ G` returning a new csr_matrix) is not — the
-construction allocates, copies, and eventually eliminates explicit
-zeros. By forcing the sparse work into a handful of clean SpMVs and
-leaving the rest to Numba, we get the best of both worlds.
+Why this matters: scipy.sparse matrix-vector products are implemented
+in C and fast per se, but each call crosses Python → scipy dispatch
+→ C → back, which on a 58×58 matrix costs ~1.5 µs of pure dispatch
+overhead — 10× the actual arithmetic. Eight such SpMVs in a hot F
+made `Mat_Mul` catastrophically slow on small networks
+(`case30` hot F was 10× worse than the for-loop form). Moving the
+matvec into `SolCF.csc_matvec` inside `inner_F` eliminates all Python
+dispatch: the helper is `@njit(cache=True)` and `inner_F` calls it as
+an intra-Numba function call, which the LLVM inline pass typically
+flattens into the caller's body. On `case30`, this drops hot F from
+≈14 µs to ≈3 µs (~4.4× speedup) without any other code change.
+
+**Fallback path** — when the matrix operand is *not* a plain sparse
+`Para` (e.g. `-G_nr`, `Mat_Mul(A, B)`, or a dense `dim=2` parameter),
+the old path is kept: `F_()` emits `_sz_mm_N = matrix_expr @ operand`
+in the wrapper (using scipy.sparse or numpy `@`) and passes
+`_sz_mm_N` as an extra dense argument to `inner_F`. These
+placeholders do not benefit from the fast path and pay the scipy
+dispatch cost per call. Dense `dim=2` parameters fire a one-shot
+`UserWarning` at `FormJac` time — see
+{ref}`Restrictions and reserved names <restrictions>`.
+
+```{note}
+The fast path reuses infrastructure that predates the `Mat_Mul`
+interface: the same `SolCF.csc_matvec` helper and the same
+`<name>_data` / `_indices` / `_indptr` / `_shape0` Param decomposition
+were introduced for the legacy `MatVecMul` operator. Before 0.8.1
+fast path, those fields were still emitted into `inner_F`'s argument
+list but never referenced — they are now the conduit for the Layer 1
+matvec. Legacy `MatVecMul` users already benefited from this pipeline;
+from 0.8.1 `Mat_Mul` users do as well, without any model-level
+changes.
+```
+
+(when-to-use-mat_mul)=
+#### When to use (and not use) `Mat_Mul`
+
+`Mat_Mul` wins decisively for **every compile and build phase** of
+the workflow: `Model` construction, `FormJac`, `made_numerical`
+(inline compile), `module_printer.render`, and — most importantly —
+the first-time Numba module compile. On a typical matpower case30
+power-flow model the compile phases are **20–40× faster** under
+`Mat_Mul` than under the equivalent element-wise for-loop
+formulation. The hot `J` call is also slightly faster (vectorised
+scatter-add in the mutable-matrix blocks). See the
+[power-flow chapter of the Solverz Cookbook](https://solverz-cookbook.readthedocs.io/en/latest/ae/pf/pf.html)
+for the full benchmark table.
+
+**Use `Mat_Mul` when**:
+
+- You are iterating on the model (changing parameters, equations, or
+  dimensions) — compile-time savings are paid on *every* rebuild and
+  dwarf the runtime differences.
+- The system has more than a handful of unknowns — for ≳ 50 unknowns
+  the scipy/Numba dispatch overhead is amortised over enough
+  arithmetic that hot F is within striking distance of (or beats)
+  the for-loop form.
+- You want compact model code. `Mat_Mul(G, e)` replaces `nb` scalar
+  `Eqn` definitions per bus and makes the equations read like the
+  paper.
+- All sparse matrices used in `Mat_Mul` are plain
+  `Param(..., dim=2, sparse=True)` — this unlocks the Layer 1 Numba
+  fast path described above.
+
+**Consider the for-loop form when** *all* of the following hold:
+
+- The system is very small (≲ 30 unknowns);
+- Your hot loop is dominated by `F` evaluations (not Jacobian, not
+  linear solve), so the raw hot-F number actually matters;
+- The module is compiled once and then reused many times, so the
+  compile-time saving of `Mat_Mul` is not recovered.
+
+This combination of conditions is rare in practice — most power-flow
+and DHS workloads hit the Jacobian assembly and linear solve at
+least as often as F, and both of those are independent of (or
+favourable to) `Mat_Mul`.
+
+**Known performance regression**: on very small networks (≈
+case30-scale) the `Mat_Mul` hot F is ~3 µs per call while the
+equivalent for-loop form runs at ~1.1 µs (≈ 2.9× slower). The
+difference is the structural cost of 8 `SolCF.csc_matvec` calls
+dispatched through `inner_F` plus the sub-function dispatch layer,
+versus 53 inlined scalar kernels the element-wise form collapses
+into. The 2 µs gap is usually invisible next to the J call
+(~55 µs) and the linear solve, but if your workload is millions of
+pure F evaluations on a tiny network, the for-loop form still wins.
+
+The gap shrinks and flips with problem size. For networks large
+enough that each SpMV does meaningful arithmetic — roughly
+case118 and above — the element-wise form's huge cold-compile cost
+and per-call dispatch overhead on every scalar `inner_F{i}` make
+`Mat_Mul` the strictly better choice on all metrics.
+
+**Matrices that fall out of the fast path** (and therefore pay the
+scipy SpMV dispatch cost on every `F_` call, ≈ 1.5 µs per SpMV):
+
+- **Negated matrices** — `Mat_Mul(-G, x)`. `G` is a plain `Para` but
+  `-G` is a `Mul(-1, G)` expression the classifier doesn't recognise.
+  Workaround: fold the sign into the coefficient of the surrounding
+  expression — write `-Mat_Mul(G, x)` instead of `Mat_Mul(-G, x)`.
+- **Dense `dim=2` params** — `Param(A, dim=2, sparse=False)`. `FormJac`
+  fires a one-shot `UserWarning` for these; they fall back to the
+  `MutableMatJacDataModule` path. Convert to sparse with
+  `csc_array(A)` and declare `sparse=True`.
+- **Nested `Mat_Mul`** — `Mat_Mul(A, Mat_Mul(B, x))`. The outer call
+  receives the inner placeholder `_sz_mm_N` as its operand, which
+  hits the fast path; the *inner* call still hits the fast path
+  because its matrix is a plain `Para`. Only the inner is made fast,
+  though, and only if both are plain Paras. Triple-nested is uncommon
+  but would degrade similarly.
+- **Matrix expressions** — `Mat_Mul(A + B, x)` or similar. The
+  classifier recognises only a bare `Para` as the matrix operand.
+  Workaround: materialise the combined matrix as a single `Param`
+  (`A + B`) outside the equation.
 
 ### Layer 2 — Mutable matrix Jacobian blocks
 

--- a/docs/src/matrix_calculus.md
+++ b/docs/src/matrix_calculus.md
@@ -312,44 +312,49 @@ expression (a variable, a slice, or a larger expression). It performs
 **three transformations at code gen time**:
 
 1. **Hoist.** Each `Mat_Mul(A, v)` is replaced by a fresh placeholder
-   variable `_mmN` (where `N` is a monotonically increasing integer
-   unique across the whole system).
+   variable `_sz_mm_N` (where `N` is a monotonically increasing integer
+   unique across the whole system). The `_sz_mm_` prefix is reserved
+   by Solverz — see {ref}`Restrictions and reserved names
+   <restrictions>` below.
 2. **Deduplicate.** Two `Mat_Mul` sub-trees that are structurally equal
    (same matrix, same operand expression after hoisting) are collapsed
    into a single placeholder. The power-flow example below computes
    `G_nr @ e` once even though both the P-balance and Q-balance
    residuals reference it.
 3. **Emit precompute statements in the wrapper.** Each placeholder gets
-   one line of the form `_mmN = A @ operand` inserted at the top of the
-   `F_()` function body, *outside* the Numba-compiled inner functions.
+   one line of the form `_sz_mm_N = A @ operand` inserted at the top of
+   the `F_()` function body, *outside* the Numba-compiled inner
+   functions.
 
 The runtime effect: the *only* scipy.sparse matrix-vector product that
 happens inside a Newton step is the one at the very top of `F_()`.
 Every downstream computation (`inner_F`, `inner_F0`, `inner_F1`, …)
-receives `_mmN` as a plain dense numpy array and can run under
+receives `_sz_mm_N` as a plain dense numpy array and can run under
 `@njit(cache=True)`:
 
 ```python
 def F_(y_, p_):
     e = y_[0:29]
     f = y_[29:58]
-    G_nr = p_["G_nr"]           # csc_array, scipy.sparse
+    G_nr = p_["G_nr"]              # csc_array, scipy.sparse
     B_nr = p_["B_nr"]
-    _mm0 = (G_nr @ e)           # ← precomputed, one scipy SpMV
-    _mm1 = (B_nr @ f)           # ← dedup: B_nr@f appears in 2 equations
-    _mm2 = (B_nr @ e)
-    _mm3 = (G_nr @ f)
-    return inner_F(_F_, e, f, p_ref, q_ref, _mm0, _mm1, _mm2, _mm3, ...)
+    _sz_mm_0 = (G_nr @ e)          # ← precomputed, one scipy SpMV
+    _sz_mm_1 = (B_nr @ f)          # ← dedup: B_nr@f appears in 2 equations
+    _sz_mm_2 = (B_nr @ e)
+    _sz_mm_3 = (G_nr @ f)
+    return inner_F(_F_, e, f, p_ref, q_ref,
+                   _sz_mm_0, _sz_mm_1, _sz_mm_2, _sz_mm_3, ...)
 
 @njit(cache=True)
-def inner_F(_F_, e, f, p_ref, q_ref, _mm0, _mm1, _mm2, _mm3, ...):
-    _F_[0:29] = inner_F0(e, f, p_ref, _mm0, _mm1, _mm2, _mm3)
+def inner_F(_F_, e, f, p_ref, q_ref,
+            _sz_mm_0, _sz_mm_1, _sz_mm_2, _sz_mm_3, ...):
+    _F_[0:29] = inner_F0(e, f, p_ref, _sz_mm_0, _sz_mm_1, _sz_mm_2, _sz_mm_3)
     _F_[29:53] = inner_F1(...)
     return _F_
 
 @njit(cache=True)
-def inner_F0(e, f, p_ref, q_ref, _mm0, _mm1, _mm2, _mm3):
-    return e * (p_ref - _mm1 + _mm0) + f * (q_ref + _mm2 + _mm3) - Pinj
+def inner_F0(e, f, p_ref, q_ref, _sz_mm_0, _sz_mm_1, _sz_mm_2, _sz_mm_3):
+    return e * (p_ref - _sz_mm_1 + _sz_mm_0) + f * (q_ref + _sz_mm_2 + _sz_mm_3) - Pinj
 ```
 
 Why this matters: scipy.sparse matrix-vector products are already
@@ -424,51 +429,62 @@ Solverz exploits this in a pattern-match compiler:
 
 4. **Generate a dedicated Numba kernel per block.** For each mutable
    matrix block the code printer emits a new top-level function named
-   `_mut_block_N`. Its signature takes the diag inner vectors, the
-   base variables needed by any row/col-scale term, and each term's
-   three mapping arrays. The body is a pure-Python / Numba scatter-add
-   loop:
+   `_mut_block_N` (where `N` is the block index). Its signature takes
+   the diag inner vectors, the base variables needed by any
+   row/col-scale term, and each term's three mapping arrays. All
+   per-block helper arrays use the reserved `_sz_mb_{N}_` prefix so
+   different blocks' mappings never collide. The body is a pure-
+   Python / Numba scatter-add loop:
 
 ```python
 # Module-level (loaded once from setting at import time):
-_mb0_diag_out_0 = setting["_mb0_diag_out_0"]
-_mb0_rs_out_0   = setting["_mb0_rs_out_0"]
-_mb0_rs_src_0   = setting["_mb0_rs_src_0"]
-_mb0_rs_dat_0   = setting["_mb0_rs_dat_0"]   # frozen G_nr.data
+_sz_mb_0_diag_out_0 = setting["_sz_mb_0_diag_out_0"]
+_sz_mb_0_diag_src_0 = setting["_sz_mb_0_diag_src_0"]
+_sz_mb_0_rs_out_0   = setting["_sz_mb_0_rs_out_0"]
+_sz_mb_0_rs_src_0   = setting["_sz_mb_0_rs_src_0"]
+_sz_mb_0_rs_dat_0   = setting["_sz_mb_0_rs_dat_0"]   # frozen G_nr.data
 ...
 
 @njit(cache=True)
-def _mut_block_0(_mb0_u0, e, f,
-                 _mb_diag_out_0, _mb_diag_src_0,
-                 _mb_rs_out_0,  _mb_rs_src_0,  _mb_rs_dat_0,
-                 _mb_rs_out_1,  _mb_rs_src_1,  _mb_rs_dat_1):
+def _mut_block_0(_sz_mb_0_u0, e, f,
+                 _sz_mb_0_diag_out_0, _sz_mb_0_diag_src_0,
+                 _sz_mb_0_rs_out_0,  _sz_mb_0_rs_src_0,  _sz_mb_0_rs_dat_0,
+                 _sz_mb_0_rs_out_1,  _sz_mb_0_rs_src_1,  _sz_mb_0_rs_dat_1):
     data = zeros(107)
     # Diagonal term: diag(G_nr@e - B_nr@f + p_ref)
-    for i in range(_mb_diag_out_0.shape[0]):
-        data[_mb_diag_out_0[i]] = _mb0_u0[_mb_diag_src_0[i]]
+    for i in range(_sz_mb_0_diag_out_0.shape[0]):
+        data[_sz_mb_0_diag_out_0[i]] += _sz_mb_0_u0[_sz_mb_0_diag_src_0[i]]
     # Row-scale term: diag(e) @ G_nr
-    _v = e
-    for i in range(_mb_rs_out_0.shape[0]):
-        data[_mb_rs_out_0[i]] += _v[_mb_rs_src_0[i]] * _mb_rs_dat_0[i]
+    for i in range(_sz_mb_0_rs_out_0.shape[0]):
+        data[_sz_mb_0_rs_out_0[i]] += e[_sz_mb_0_rs_src_0[i]] * _sz_mb_0_rs_dat_0[i]
     # Row-scale term: diag(f) @ B_nr
-    _v = f
-    for i in range(_mb_rs_out_1.shape[0]):
-        data[_mb_rs_out_1[i]] += _v[_mb_rs_src_1[i]] * _mb_rs_dat_1[i]
+    for i in range(_sz_mb_0_rs_out_1.shape[0]):
+        data[_sz_mb_0_rs_out_1[i]] += f[_sz_mb_0_rs_src_1[i]] * _sz_mb_0_rs_dat_1[i]
     return data
+```
+
+```{note}
+Every scatter-add loop uses `+=`, not `=`, including the diagonal
+terms. This matters when a block contains **multiple independent
+`Diag(...)` additive terms** whose output positions coincide — for
+example the Jacobian of `x*(A@x) + x*(B@x)` produces `diag(A@x)` and
+`diag(B@x)`, both landing on the same `(i,i)` positions. The `+=`
+accumulates their contributions correctly; an earlier implementation
+used `=` and silently dropped one of the two terms.
 ```
 
 5. **Wire the kernel up in the `J_` wrapper.** For each block the
    wrapper emits: (a) one line per diag term that materialises its
-   inner vector using scipy.sparse (e.g. `_mb0_u0 = p_ref - (B_nr@f) +
-   (G_nr@e)`); (b) a call to `_mut_block_N(...)` passing the inner
-   vectors, base variables, and mapping arrays; (c) an assignment of
-   the returned `data` array into the appropriate slice of the overall
-   Jacobian `_data_`.
+   inner vector using scipy.sparse (e.g. `_sz_mb_0_u0 = p_ref -
+   (B_nr@f) + (G_nr@e)`); (b) a call to `_mut_block_N(...)` passing
+   the inner vectors, base variables, and mapping arrays; (c) an
+   assignment of the returned `data` array into the appropriate slice
+   of the overall Jacobian `_data_`.
 
    Crucially, each block's **scipy work is capped at one SpMV per diag
    term** — nothing else in the block touches sparse matrices at
    runtime. The data for row/col-scale terms comes straight from the
-   pre-baked `_mb_rs_dat_k` arrays.
+   pre-baked `_sz_mb_{N}_rs_dat_{k}` arrays.
 
 The net effect on a Newton step is that the Jacobian assembly cost is
 dominated by (i) the constant `inner_J` call for element-wise blocks
@@ -601,6 +617,109 @@ models with many rows and few blocks the advantage is small; for
 models with many blocks per variable (such as power flow, with
 distinct $\partial/\partial e$ and $\partial/\partial f$ blocks for
 both $P$ and $Q$ balances) the advantage compounds.
+
+(restrictions)=
+## Restrictions and reserved names
+
+`Mat_Mul` imposes a few hard restrictions that are enforced at model
+build time. Each one prevents a class of silent-wrong-answer bugs that
+would otherwise slip past the generated Jacobian.
+
+### Triggerable / time-series parameters cannot appear in a Mat_Mul equation
+
+A parameter declared with `triggerable=True` or as a `TimeSeriesParam`
+is **rejected at `FormJac` time** if it appears in the same equation
+as any `Mat_Mul`:
+
+```python
+m.K = Param('K', [...], triggerable=True, trigger_var=['x'], trigger_fun=...)
+m.A = Param('A', [[...]], dim=2, sparse=True)
+m.eqn = Eqn('f', m.K * m.x + Mat_Mul(m.A, m.x) - m.b)
+smdl, y0 = m.create_instance()
+smdl.FormJac(y0)
+# ⇒ NotImplementedError: Equation 'f' uses ``Mat_Mul`` together with
+#   triggerable parameter 'K'. This combination is not currently
+#   supported because the Mat_Mul code generator assumes matrix
+#   parameters are immutable after ``create_instance()``.
+```
+
+**Why:** the mutable-matrix analyser freezes every non-variable scaling
+vector into a Numba kernel closure at code-gen time. If `K` were
+triggerable, its `trigger_fun` would fire at runtime and *change* the
+value, but the scatter-add loops would keep using the frozen numbers —
+producing wrong Newton steps without raising any error. Rejecting the
+combination at build time is the only safe choice.
+
+**Workaround:** split the matrix assembly into an explicit elementwise
+form. If you need per-row scaling that depends on `x`, write the
+per-row equation directly (one scalar `Eqn` per row) instead of using
+`Mat_Mul` on a triggerable parameter.
+
+### Reserved symbol prefixes
+
+User symbols (`Var`, `Param`, `iVar`, `Para`, ...) are rejected at
+construction time if their name starts with any of:
+
+| Prefix | Used for |
+|---|---|
+| `_sz_mm_` | Mat_Mul precompute placeholders in the `F_`/`J_` wrapper (e.g. `_sz_mm_0 = G @ e`). |
+| `_sz_mb_` | Mutable-matrix Jacobian block helpers (diag inner vectors, row/col-scale scaling vectors, mapping arrays). |
+
+```python
+m.x = Var('_sz_mm_0', [1.0])
+# ⇒ ValueError: Symbol name '_sz_mm_0' starts with Solverz-reserved
+#   internal prefix '_sz_mm_'. This prefix is used by the code
+#   generator for Mat_Mul / mutable-matrix Jacobian helper names and
+#   cannot be used for user variables or parameters.
+```
+
+**Why:** the code printer emits an unbounded family of helper
+identifiers of the form `<prefix><int>` and needs to know that none of
+them will collide with a user symbol. The prefix ban is the simplest
+way to guarantee that — users pick any name that does *not* start with
+`_sz_mm_` / `_sz_mb_`, and the code printer is free to use any name
+that *does*.
+
+### Dense `dim=2` parameters emit a performance warning
+
+A parameter declared with `dim=2, sparse=False` that appears inside a
+`Mat_Mul` is legal — the fallback path handles it correctly — but it
+forfeits every optimisation described above:
+
+- no sparse pattern precomputation (the "output sparsity pattern" step
+  produces a fully dense block),
+- no `_sz_mb_{N}_rs_dat_k` scatter-add (the block falls through to the
+  `MutableMatJacDataModule` fancy-indexing path),
+- each Jacobian call allocates and populates a dense intermediate.
+
+Solverz emits a one-shot `UserWarning` at `FormJac` time, **once per
+offending parameter**, to flag the performance cost:
+
+```python
+m.A = Param('A', np.array([[2.0, 1.0], [1.0, 3.0]]), dim=2, sparse=False)
+m.eqn = Eqn('f', m.x * Mat_Mul(m.A, m.x) - m.b)
+smdl, y0 = m.create_instance()
+smdl.FormJac(y0)
+# UserWarning: Parameter 'A' is a dense 2-D ``Param(..., dim=2,
+#   sparse=False)`` used inside ``Mat_Mul``. Dense matrices bypass
+#   the vectorised mutable-matrix Jacobian fast path and fall back
+#   to a slower scipy/ndarray indexing path. Declare 'A' with
+#   ``sparse=True`` for substantially better performance.
+```
+
+**How to fix:** wrap the value in a scipy.sparse container and declare
+`sparse=True`:
+
+```python
+from scipy.sparse import csc_array
+m.A = Param('A', csc_array(np.array([[2.0, 1.0], [1.0, 3.0]])),
+            dim=2, sparse=True)
+```
+
+On a dense 2×2 matrix the difference is invisible, but for anything
+larger than a few dozen rows the sparse path is substantially faster
+and (more importantly) keeps the Jacobian assembly off the fallback
+path.
 
 ## API Reference
 

--- a/docs/src/matrix_calculus.md
+++ b/docs/src/matrix_calculus.md
@@ -775,35 +775,96 @@ both $P$ and $Q$ balances) the advantage compounds.
 build time. Each one prevents a class of silent-wrong-answer bugs that
 would otherwise slip past the generated Jacobian.
 
-### Triggerable / time-series parameters cannot appear in a Mat_Mul equation
+### Time-varying sparse `dim=2` parameters are rejected at construction
 
-A parameter declared with `triggerable=True` or as a `TimeSeriesParam`
-is **rejected at `FormJac` time** if it appears in the same equation
-as any `Mat_Mul`:
+Solverz does not support sparse `dim=2` `Param`s whose values change
+at runtime. A declaration like:
 
 ```python
-m.K = Param('K', [...], triggerable=True, trigger_var=['x'], trigger_fun=...)
-m.A = Param('A', [[...]], dim=2, sparse=True)
-m.eqn = Eqn('f', m.K * m.x + Mat_Mul(m.A, m.x) - m.b)
-smdl, y0 = m.create_instance()
-smdl.FormJac(y0)
-# ⇒ NotImplementedError: Equation 'f' uses ``Mat_Mul`` together with
-#   triggerable parameter 'K'. This combination is not currently
-#   supported because the Mat_Mul code generator assumes matrix
-#   parameters are immutable after ``create_instance()``.
+from scipy.sparse import csc_array
+m.K = Param('K',
+            csc_array([[1, 0], [0, 1]]),
+            dim=2, sparse=True,
+            triggerable=True,
+            trigger_var=['x'],
+            trigger_fun=lambda x: csc_array([[2*x[0], 0], [0, 2*x[1]]]))
+# ⇒ NotImplementedError: Parameter 'K': a sparse 2-D ``Param`` cannot
+#   be declared ``triggerable=True``. Time-varying sparse matrices are
+#   unsupported because Solverz's code generation caches the matrix's
+#   CSC fields at model-build time; a runtime trigger update would
+#   silently be ignored.
 ```
 
-**Why:** the mutable-matrix analyser freezes every non-variable scaling
-vector into a Numba kernel closure at code-gen time. If `K` were
-triggerable, its `trigger_fun` would fire at runtime and *change* the
-value, but the scatter-add loops would keep using the frozen numbers —
-producing wrong Newton steps without raising any error. Rejecting the
-combination at build time is the only safe choice.
+and the equivalent `TimeSeriesParam`:
 
-**Workaround:** split the matrix assembly into an explicit elementwise
-form. If you need per-row scaling that depends on `x`, write the
-per-row equation directly (one scalar `Eqn` per row) instead of using
-`Mat_Mul` on a triggerable parameter.
+```python
+m.G = TimeSeriesParam('G',
+                      v_series=[...],
+                      time_series=[...],
+                      value=np.eye(3),
+                      dim=2, sparse=True)
+# ⇒ NotImplementedError: Parameter 'G': a sparse 2-D
+#   ``TimeSeriesParam`` is not supported.
+```
+
+both raise **at the point of construction**, not deep inside
+`FormJac`, so the error points at the exact line where the user
+wrote the offending declaration.
+
+**Why:** every Solverz code path that consumes a sparse `dim=2`
+`Param` caches its CSC decomposition at model-build time:
+
+- The legacy `MatVecMul` code path decomposes every sparse `dim=2`
+  `Param` into flat arrays (`<name>_data`, `<name>_indices`,
+  `<name>_indptr`, `<name>_shape0`) in `Solverz/model/basic.py:56`,
+  which are stored in `p_` and passed to `inner_F` as read-only
+  numpy arrays.
+- The 0.8.1 `Mat_Mul` `SolCF.csc_matvec` fast path reuses those
+  same CSC flats inside `inner_F` to do the matvec in `@njit` land.
+- The mutable-matrix Jacobian scatter-add kernel caches the
+  matrix's `.data` array directly as a `_sz_mb_{N}_rs_dat_{k}`
+  setting entry loaded at module import time.
+
+None of these caches are invalidated when `p_["K"].trigger_fun`
+fires or `p_["G"].get_v_t(t)` returns a fresh matrix. The runtime
+update simply gets lost, the Jacobian keeps using the initial
+values, and the Newton iteration either diverges or converges to
+the wrong solution — silently.
+
+Historically the check was narrow (only equations containing
+`Mat_Mul` were rejected, and the check ran at `FormJac` time). In
+the 0.8.1 hotfix the policy broadened to cover every sparse
+`dim=2` time-varying `Param`, regardless of where or whether it is
+used. The check now lives in `ParamBase.__init__` and
+`TimeSeriesParam.__init__`, with an unconditional backstop in
+`Equations._check_no_timevar_sparse_matrices` that runs on every
+`FormJac` call in case a tainted `Param` was constructed via
+`__new__` + attribute assignment (which bypasses the `__init__`
+check).
+
+**Workarounds** — all of these are supported:
+
+- **Triggerable / time-series *vectors* next to a `Mat_Mul`.**
+  Scalar or 1-D time-varying parameters are fine; only the `dim=2`
+  + `sparse=True` combination is rejected. Write
+  `m.K * m.x + Mat_Mul(m.A, m.x) - m.b` with `K` a triggerable 1-D
+  vector and `A` a plain sparse 2-D matrix — the wrapper rebuilds
+  `K` on every Newton step via the `trigger_var` mechanism and the
+  `Mat_Mul(A, x)` fast path uses the unchanged `A`.
+- **Element-wise rewrite.** If you genuinely need the matrix
+  itself to evolve, write the residual out one scalar `Eqn` per
+  row, with the per-row coefficients as 1-D `Param`s or
+  `TimeSeriesParam`s. The element-wise form has no CSC caching —
+  every call re-evaluates the full trigonometric / algebraic
+  expression via pure numpy / numba.
+- **Dense `dim=2` parameters (`sparse=False`).** The
+  `MutableMatJacDataModule` fallback path used for dense matrices
+  re-evaluates the entire block expression via scipy/numpy on
+  every `J_()` call, so `get_v_t(t)` updates DO propagate. Dense
+  parameters do not get the `csc_matvec` fast path, but they're a
+  correct (if slower) way to carry a time-varying matrix through
+  the solver. A `UserWarning` still fires once per such parameter
+  to flag the performance cost.
 
 ### Reserved symbol prefixes
 

--- a/docs/src/matrix_calculus.md
+++ b/docs/src/matrix_calculus.md
@@ -55,8 +55,14 @@ Solverz relies on this assumption for maximum runtime efficiency:
 If your application truly needs to update sparse-matrix values between solves
 (e.g., sweeping a parameter), rebuild the model with `model.create_instance()`
 each time. Mutating `p_["A"].data` after creation will silently produce wrong
-Jacobians because the stored index mappings and precomputed factors no longer
-match.
+Jacobians **for matrices that flow through the vectorised Mat_Mul fast path** —
+scatter-add kernels cache `M.data` at analysis time and the cache becomes
+stale. Matrices that only land in the `MutableMatJacDataModule` fallback path
+(see {ref}`Fallback path <fallback-path>`) re-evaluate the full expression on
+every `J_()` call and would reflect the mutation, but there is no way to
+guarantee a particular block won't be *promoted* to the fast path in a future
+release, so the rule is still: **do not mutate sparse matrix params
+post-build**.
 
 Dense parameters (`Param(..., dim=2, sparse=False)`) are fine to update via
 `mdl.p["name"] = new_value`; the restriction only applies to **sparse**
@@ -391,13 +397,31 @@ Solverz exploits this in a pattern-match compiler:
 
    | Shape | Generated code contribution |
    |---|---|
-   | `Diag(u_expr)` (diagonal term) | `data[out_pos] = u[src_idx]` |
+   | `Diag(u_expr)` (diagonal term) | `data[out_pos] += u[src_idx]` |
    | `Mat_Mul(Diag(v), M)` (row-scale) | `data[out_pos] += v[src_row] * M_data[k]` |
    | `Mat_Mul(M, Diag(v))` (col-scale) | `data[out_pos] += v[src_col] * M_data[k]` |
 
-   Unrecognised terms are deferred to a correct-but-slower fallback
-   that evaluates the full sub-expression via scipy.sparse and extracts
-   values by fancy indexing.
+   **A term is deferred to the fallback path when any of the
+   following is true**:
+
+   - it has a non-unit numeric coefficient other than `±1` (e.g.
+     `3 * Diag(x)`) — the analyser only unwraps `±1` via
+     `_extract_sign_and_core`;
+   - it is `Mat_Mul(Diag(v), X)` or `Mat_Mul(X, Diag(v))` where
+     ``X`` is **not** a plain `Para` (or `-Para`) — for instance
+     a matrix expression such as `A @ B`, or a user-constructed
+     product that the matrix calculus engine hasn't simplified
+     down to a single leaf matrix;
+   - it is a ``Mat_Mul`` with three or more arguments that the
+     matrix-calculus engine didn't fold into a nested binary form;
+   - it is any other shape the classifier doesn't recognise
+     (transpose of a mutable matrix, element-wise matrix product,
+     a non-sparse matrix leaf, etc.).
+
+   Unrecognised terms are deferred to the
+   {ref}`fallback path <fallback-path>`, which is correct but slower:
+   it evaluates the full sub-expression via scipy.sparse on every
+   `J_()` call and extracts values by fancy indexing.
 
 2. **Precompute the output sparsity pattern (once).** At model
    initialisation (inside `FormJac`, `Solverz/equation/equations.py`),
@@ -534,6 +558,7 @@ original pre-0.8 architecture (direct `@njit` on `inner_F` receiving
 only dense vectors and scalar params). Performance on pure
 element-wise models is therefore unchanged by the Mat_Mul rewrite.
 
+(fallback-path)=
 ### Fallback path
 
 If a Jacobian block contains a term whose shape the symbolic analyser

--- a/docs/src/matrix_calculus.md
+++ b/docs/src/matrix_calculus.md
@@ -34,6 +34,35 @@ See also: [matrixcalculus.org](https://www.matrixcalculus.org/)
 `scipy.sparse` directly, which is both faster and supports full matrix calculus.
 ```
 
+```{warning} **Sparse matrices MUST be immutable after modelling**
+
+All sparse matrix parameters declared with `Param(..., dim=2, sparse=True)` are
+assumed to be **immutable** (both sparsity pattern *and* numerical values) once
+modelling is complete and `model.create_instance()` has been called.
+
+Solverz relies on this assumption for maximum runtime efficiency:
+
+- At code-generation time, the sparsity pattern of every mutable-matrix Jacobian
+  block is analysed *once*, the output data-array layout is fixed, and a pre-
+  computed index mapping is baked into a Numba-compiled scatter-add loop.
+- At runtime, each Newton step assembles Jacobian block data by directly
+  indexing into `Matrix.data` using the pre-computed row/column mappings —
+  **no scipy.sparse matrix is constructed per iteration**.
+- For sparse-matrix parameters used in `Mat_Mul(A, x)`, the matrix-vector
+  product `A @ x` is precomputed in the `F_` wrapper and passed as a dense
+  vector to the `@njit`-compiled equation functions.
+
+If your application truly needs to update sparse-matrix values between solves
+(e.g., sweeping a parameter), rebuild the model with `model.create_instance()`
+each time. Mutating `p_["A"].data` after creation will silently produce wrong
+Jacobians because the stored index mappings and precomputed factors no longer
+match.
+
+Dense parameters (`Param(..., dim=2, sparse=False)`) are fine to update via
+`mdl.p["name"] = new_value`; the restriction only applies to **sparse**
+dim=2 parameters.
+```
+
 All element-wise functions (exp, sin, cos, ln, Abs) can be composed with matrix operations:
 
 ```python
@@ -50,73 +79,158 @@ Solverz will automatically compute $\frac{\partial}{\partial x} e^{Ax} = \operat
 
 ## How It Works
 
+The matrix calculus engine is a four-stage pipeline: each expression is
+lifted into Einstein index notation, rebuilt as a computation DAG,
+differentiated forward through the DAG, and finally collapsed back to
+ordinary matrix/vector operations. We walk through each stage with a
+running example from power flow.
+
 ### 1. Einstein Index Notation
 
-Every tensor is labelled with indices:
+Every tensor is labelled with one index per axis:
 
-- **Scalar**: no index (e.g., $\alpha$)
-- **Vector** $x$: single index $x_i$
-- **Matrix** $A$: two indices $A_{ij}$
+- **Scalar**: no index (e.g., $\alpha$). Zeroth-order tensor, no axes.
+- **Vector** $x \in \mathbb{R}^n$: a single index $x_i$, where $i$ ranges
+  over $\{1, \dots, n\}$. The index *names* the axis; the letter used is
+  arbitrary, only its pattern of repetition matters.
+- **Matrix** $A \in \mathbb{R}^{m \times n}$: two indices $A_{ij}$. The
+  first index $i$ labels rows, the second $j$ labels columns.
 
-Repeated indices in a product imply summation (contraction). For example,
-$A_{ij} x_j$ means $\sum_j A_{ij} x_j = (Ax)_i$.
+A **repeated index inside a product** implies *summation*
+(Einstein summation convention, or *contraction*):
+
+```{math}
+A_{ij}\, x_j \;\equiv\; \sum_{j=1}^{n} A_{ij}\, x_j \;=\; (Ax)_i.
+```
+
+Here $j$ is repeated (contracted — it disappears in the result), while
+$i$ is a **free index** that labels the resulting vector's axis.
+Conventionally we write the non-contracted indices on the left of the
+expression, so the indices of the left-hand side $(Ax)_i$ match the
+remaining free indices $i$ on the right.
+
+The benefit of this notation is that the *shape* of an expression is
+fully encoded in its index signature. Element-wise multiplication uses
+repeated indices *without* contraction:
+
+```{math}
+(x \odot y)_i \;=\; x_i\, y_i,
+```
+
+and the outer product uses two different free indices:
+
+```{math}
+(x\, y^\top)_{ij} \;=\; x_i\, y_j.
+```
 
 ### 2. Computation DAG
 
-The expression is parsed into a directed acyclic graph (DAG):
+Solverz parses each equation's symbolic expression into a **directed
+acyclic graph (DAG)**:
 
-- **Leaf nodes**: variables ($x$, $y$) and parameters ($A$, $B$, $G$)
-- **Internal nodes**: operations ($+$, $\times$, $@$, $f(\cdot)$)
-- **Root node**: the output expression
+- **Leaf nodes** — variables ($x$, $y$) and parameters ($A$, $B$, $G$).
+  Each leaf carries its index signature ($x_i$, $A_{ij}$, etc.).
+- **Internal nodes** — operations: addition $+$, element-wise product
+  $\odot$, matrix product $@$, element-wise unary function $f(\cdot)$.
+- **Root node** — the output expression whose Jacobian we want.
 
-For example, $e \odot (Ge - Bf)$ becomes:
+For the power flow active-power sub-expression $e \odot (Ge - Bf)$:
 
 ```
-        *[i]          ← element-wise multiply
+        *[i]          ← element-wise multiply (free index i)
        /    \
-     e[i]   -[i]      ← subtraction
+     e[i]   -[i]      ← subtraction (free index i)
            /    \
-       @[i]    @[i]    ← matrix-vector products
+       @[i]    @[i]   ← matrix-vector products, contraction on j
        / \     / \
      G[ij] e[j] B[ij] f[j]
 ```
 
+Each node remembers its free index set. The matrix product nodes
+`@[i]` each *contract* index $j$ between $G_{ij}$ and $e_j$, so the
+result has free index $i$. The subtraction and element-wise product
+keep $i$ as their only free index, so the whole expression has index
+signature $[i]$ — a vector.
+
 ### 3. Forward-Mode Automatic Differentiation
 
-Derivatives propagate from **leaves to root** (pushforward):
+To obtain $\partial f / \partial x$ where $f$ is the root and $x$ is
+some leaf variable, derivatives propagate from **leaves upward to the
+root** (pushforward, a.k.a. forward-mode AD). Every internal node
+computes its own Jacobian contribution and combines it with the
+Jacobians already accumulated at its children.
 
-1. **Leaf variables**: $\frac{\partial x_j}{\partial x_j} = 1$ (identity), $\frac{\partial x_j}{\partial y_k} = 0$
+Throughout this section, $A_{s_1}$ and $B_{s_2}$ denote the free
+indices of the two operands (before differentiation), $s_3$ denotes the
+free index of the result, and $s_4$ is the **derivative-direction
+index** — the axis along which we differentiate, equal to the free
+index of the variable $x$ we differentiate with respect to. Tilded
+tensors $\tilde A, \tilde B$ carry one *extra* axis
+(labelled $s_4$) compared to $A, B$: the derivative of a rank-$k$
+tensor w.r.t. a rank-1 variable is a rank-$(k{+}1)$ tensor.
+
+1. **Leaf variables.** Differentiating $x_j$ w.r.t. $x_{s_4}$ gives the
+   Kronecker delta:
+
+   ```{math}
+   \tilde{x}_{j\,s_4} \;=\; \frac{\partial x_j}{\partial x_{s_4}} \;=\; \delta_{j s_4}.
+   ```
+
+   All other variables (and all parameters) have derivative $0$ w.r.t.
+   $x$.
 
 2. **Multiplication** (product rule in index notation):
 
 ```{math}
-\tilde{C}_{s_3 s_4} = B_{s_2} \cdot \tilde{A}_{s_1 s_4} + A_{s_1} \cdot \tilde{B}_{s_2 s_4}
+\tilde{C}_{s_3\,s_4} \;=\; B_{s_2}\cdot\tilde{A}_{s_1\,s_4}
+                      \;+\; A_{s_1}\cdot\tilde{B}_{s_2\,s_4}
 ```
 
-   where $s_1, s_2, s_3$ are the operand/result indices and $s_4$ is the derivative direction.
+   where $A_{s_1} \cdot B_{s_2} = C_{s_3}$ is the original product (the
+   specific index pattern $s_1, s_2 \to s_3$ depends on the product
+   type — element-wise, matrix-vector, or matrix-matrix). The two
+   summands encode "differentiate the first factor, keep the second"
+   plus "keep the first factor, differentiate the second".
 
-3. **Element-wise unary function** $f$:
+3. **Element-wise unary function** $f$ (e.g. $\exp$, $\sin$, $\ln$):
+   since $f$ acts point-wise, the chain rule gives
 
 ```{math}
-\frac{\partial f(A)}{\partial x} = f'(A) \odot \frac{\partial A}{\partial x}
+\frac{\partial f(A_{s_1})}{\partial x_{s_4}} \;=\; f'(A_{s_1})\odot\tilde{A}_{s_1\,s_4}.
 ```
 
-4. **Addition**: $\frac{\partial (A + B)}{\partial x} = \frac{\partial A}{\partial x} + \frac{\partial B}{\partial x}$
+   The derivative $f'$ is also computed element-wise and multiplied
+   (Hadamard) with the child's Jacobian.
+
+4. **Addition**. Linearity:
+
+```{math}
+\tilde{(A+B)}_{s_3\,s_4} \;=\; \tilde{A}_{s_1\,s_4} + \tilde{B}_{s_2\,s_4}.
+```
 
 ### 4. TMul2Mul: Index Resolution
 
-After differentiation, tensor index expressions are resolved back to matrix operations.
-The key rules are:
+After the forward pass, derivatives live as tensor expressions labelled
+with free indices. The **TMul2Mul** stage reads the index pattern of
+each product and emits the corresponding concrete matrix / vector
+operation. Each row of the table has the form $(s_1, s_2, s_3)$: the
+free indices of the left operand, right operand, and the result.
 
-| Index Pattern | Matrix Operation | Meaning |
-|---------------|-----------------|---------|
-| $(i, i, i)$ | $x \odot y$ | element-wise |
-| $(i, j, ij)$ | $x \cdot y^T$ | outer product |
-| $(ij, j, i)$ | $A y$ | matrix-vector product |
-| $(ij, jk, ik)$ | $AB$ | matrix multiplication |
-| $(i, ij, ij)$ | $\operatorname{diag}(x) A$ | diagonal scaling |
-| $(ij, jj, ij)$ | $A \operatorname{diag}(y)$ | right diagonal scaling |
-| $(i, ii, ii)$ | $\operatorname{diag}(x \odot y)$ | diagonal from element-wise |
+| Index pattern $(s_1, s_2, s_3)$ | Matrix operation | Meaning |
+|---|---|---|
+| $(i,\; i,\; i)$                 | $x \odot y$                            | element-wise multiply — both operands share axis $i$, no contraction |
+| $(i,\; j,\; ij)$                | $x\,y^\top$                            | outer product — two disjoint free indices survive into the result |
+| $(ij,\; j,\; i)$                | $A\,y$                                 | matrix-vector: index $j$ is shared (contracted), $i$ survives |
+| $(ij,\; jk,\; ik)$              | $A\,B$                                 | matrix-matrix: inner $j$ is contracted, $(i,k)$ survive |
+| $(i,\; ij,\; ij)$               | $\operatorname{diag}(x)\,A$            | left diagonal scaling — scale each row of $A$ by the matching entry of $x$ |
+| $(ij,\; j,\; ij)$               | $A\,\operatorname{diag}(y)$            | right diagonal scaling — scale each column of $A$ by the matching entry of $y$ |
+| $(i,\; ii,\; ii)$               | $\operatorname{diag}(x \odot y)$       | diagonal-from-element-wise — used when a product has matching repeated indices $(ii)$ on one operand |
+
+The key insight is that every well-formed index pattern maps to one
+concrete sparse-preserving operation. Patterns like $(ij, ij, ij)$ that
+don't match the table are either simplified earlier (e.g. $(ij, ij, ij)
+\to A \odot B$, element-wise matrix product) or emitted via a fallback
+that produces a dense matrix.
 
 ## Application Examples
 
@@ -170,6 +284,323 @@ expr = Mat_Mul(mL, K * Abs(m) * m)
 TE = TensorExpr(expr)
 print(TE.diff(m))  # mL@(diag(K*Abs(m)) + diag(K*m*Sign(m)))
 ```
+
+## How numerical code is generated and optimized
+
+When `module_printer` compiles an equation system that contains
+`Mat_Mul`, it applies a **three-layer optimisation strategy** to make
+the generated `F_`/`J_` functions run as fast as possible. All three
+layers operate on the same insight: *at modelling time we already know
+what the equations and their Jacobians look like* — so every
+computation that does not depend on the current iterate $y$ can be
+lifted out of the hot loop and paid for once, at code generation or
+module load.
+
+```{warning}
+Everything below assumes **sparse matrix parameters are immutable**
+after `model.create_instance()`. See the warning earlier in this
+document. Every layer described here bakes in the matrix's sparsity
+pattern or its `.data` values as a constant; mutating them in-place
+will silently corrupt results without raising any error.
+```
+
+### Layer 1 — Precompute `Mat_Mul` in the `F_` wrapper
+
+The code printer walks every residual RHS looking for `Mat_Mul(A, v)`
+sub-trees, where `A` is a sparse parameter and `v` is any vector-valued
+expression (a variable, a slice, or a larger expression). It performs
+**three transformations at code gen time**:
+
+1. **Hoist.** Each `Mat_Mul(A, v)` is replaced by a fresh placeholder
+   variable `_mmN` (where `N` is a monotonically increasing integer
+   unique across the whole system).
+2. **Deduplicate.** Two `Mat_Mul` sub-trees that are structurally equal
+   (same matrix, same operand expression after hoisting) are collapsed
+   into a single placeholder. The power-flow example below computes
+   `G_nr @ e` once even though both the P-balance and Q-balance
+   residuals reference it.
+3. **Emit precompute statements in the wrapper.** Each placeholder gets
+   one line of the form `_mmN = A @ operand` inserted at the top of the
+   `F_()` function body, *outside* the Numba-compiled inner functions.
+
+The runtime effect: the *only* scipy.sparse matrix-vector product that
+happens inside a Newton step is the one at the very top of `F_()`.
+Every downstream computation (`inner_F`, `inner_F0`, `inner_F1`, …)
+receives `_mmN` as a plain dense numpy array and can run under
+`@njit(cache=True)`:
+
+```python
+def F_(y_, p_):
+    e = y_[0:29]
+    f = y_[29:58]
+    G_nr = p_["G_nr"]           # csc_array, scipy.sparse
+    B_nr = p_["B_nr"]
+    _mm0 = (G_nr @ e)           # ← precomputed, one scipy SpMV
+    _mm1 = (B_nr @ f)           # ← dedup: B_nr@f appears in 2 equations
+    _mm2 = (B_nr @ e)
+    _mm3 = (G_nr @ f)
+    return inner_F(_F_, e, f, p_ref, q_ref, _mm0, _mm1, _mm2, _mm3, ...)
+
+@njit(cache=True)
+def inner_F(_F_, e, f, p_ref, q_ref, _mm0, _mm1, _mm2, _mm3, ...):
+    _F_[0:29] = inner_F0(e, f, p_ref, _mm0, _mm1, _mm2, _mm3)
+    _F_[29:53] = inner_F1(...)
+    return _F_
+
+@njit(cache=True)
+def inner_F0(e, f, p_ref, q_ref, _mm0, _mm1, _mm2, _mm3):
+    return e * (p_ref - _mm1 + _mm0) + f * (q_ref + _mm2 + _mm3) - Pinj
+```
+
+Why this matters: scipy.sparse matrix-vector products are already
+implemented in C and fairly fast, but *constructing intermediate sparse
+matrices* (e.g. `diag(e) @ G` returning a new csr_matrix) is not — the
+construction allocates, copies, and eventually eliminates explicit
+zeros. By forcing the sparse work into a handful of clean SpMVs and
+leaving the rest to Numba, we get the best of both worlds.
+
+### Layer 2 — Mutable matrix Jacobian blocks
+
+The Jacobian is handled by a **separate, symbolic decomposition**
+because its blocks are matrices (not vectors) whose structure depends
+on the full expression. Consider the power-flow block
+
+```{math}
+\frac{\partial P}{\partial e} \;=\;
+  \operatorname{diag}\!\bigl(G\,e - B\,f + p_\text{ref}\bigr)
+  \;+\; \operatorname{diag}(e)\,G
+  \;+\; \operatorname{diag}(f)\,B.
+```
+
+All three terms are *mutable* — they depend on $e$ and $f$ and must be
+re-evaluated every Newton step. But their **sparsity pattern is
+constant**: the union of the diagonal, the pattern of $G$, and the
+pattern of $B$ — all fixed at modelling time.
+
+Solverz exploits this in a pattern-match compiler:
+
+1. **Parse the block into typed terms.** The symbolic analyser walks
+   the SymPy expression tree (implemented in
+   `Solverz/code_printer/python/module/mutable_mat_analyzer.py`). Each
+   additive term is classified as one of:
+
+   | Shape | Generated code contribution |
+   |---|---|
+   | `Diag(u_expr)` (diagonal term) | `data[out_pos] = u[src_idx]` |
+   | `Mat_Mul(Diag(v), M)` (row-scale) | `data[out_pos] += v[src_row] * M_data[k]` |
+   | `Mat_Mul(M, Diag(v))` (col-scale) | `data[out_pos] += v[src_col] * M_data[k]` |
+
+   Unrecognised terms are deferred to a correct-but-slower fallback
+   that evaluates the full sub-expression via scipy.sparse and extracts
+   values by fancy indexing.
+
+2. **Precompute the output sparsity pattern (once).** At model
+   initialisation (inside `FormJac`, `Solverz/equation/equations.py`),
+   every mutable-matrix block is evaluated *one* time with all
+   variables perturbed to distinct non-zero values and all `Diag`
+   nodes substituted with `SpDiag` (which emits `sps.diags` instead of
+   the dense `np.diagflat`). This perturbed evaluation is the entire
+   reason we go to the trouble of the `SpDiag` substitution: using
+   non-zero variable values *guarantees* that no term accidentally
+   collapses to zero at $y_0$ (which would happen in a flat-start power
+   flow where $f = 0$ and `sps.diags(f)@B` is empty). The resulting
+   sparse matrix gives us the **union of all terms' patterns** — the
+   structural upper bound that the runtime block must fit into.
+
+3. **Precompute the index mapping arrays (once).** For each recognised
+   term, the analyser builds three numpy arrays:
+
+   - `out_pos[k]` — the index into the block's output `data` array
+     where the $k$-th nonzero contribution of this term lands.
+   - `src_idx[k]` — for diagonal terms, the row $i$ in the inner
+     vector $u$ to read from; for row-scale terms, the row of $M$'s
+     $k$-th nonzero; for col-scale terms, the column.
+   - `mat_data` (row/col-scale terms only) — a direct reference to
+     `M.data` (which is why the matrix must be immutable).
+
+   These arrays are stored inside `setting`, a per-module dict that
+   also holds things like the CSC `row`, `col`, and initial `data`
+   for the full Jacobian.
+
+4. **Generate a dedicated Numba kernel per block.** For each mutable
+   matrix block the code printer emits a new top-level function named
+   `_mut_block_N`. Its signature takes the diag inner vectors, the
+   base variables needed by any row/col-scale term, and each term's
+   three mapping arrays. The body is a pure-Python / Numba scatter-add
+   loop:
+
+```python
+# Module-level (loaded once from setting at import time):
+_mb0_diag_out_0 = setting["_mb0_diag_out_0"]
+_mb0_rs_out_0   = setting["_mb0_rs_out_0"]
+_mb0_rs_src_0   = setting["_mb0_rs_src_0"]
+_mb0_rs_dat_0   = setting["_mb0_rs_dat_0"]   # frozen G_nr.data
+...
+
+@njit(cache=True)
+def _mut_block_0(_mb0_u0, e, f,
+                 _mb_diag_out_0, _mb_diag_src_0,
+                 _mb_rs_out_0,  _mb_rs_src_0,  _mb_rs_dat_0,
+                 _mb_rs_out_1,  _mb_rs_src_1,  _mb_rs_dat_1):
+    data = zeros(107)
+    # Diagonal term: diag(G_nr@e - B_nr@f + p_ref)
+    for i in range(_mb_diag_out_0.shape[0]):
+        data[_mb_diag_out_0[i]] = _mb0_u0[_mb_diag_src_0[i]]
+    # Row-scale term: diag(e) @ G_nr
+    _v = e
+    for i in range(_mb_rs_out_0.shape[0]):
+        data[_mb_rs_out_0[i]] += _v[_mb_rs_src_0[i]] * _mb_rs_dat_0[i]
+    # Row-scale term: diag(f) @ B_nr
+    _v = f
+    for i in range(_mb_rs_out_1.shape[0]):
+        data[_mb_rs_out_1[i]] += _v[_mb_rs_src_1[i]] * _mb_rs_dat_1[i]
+    return data
+```
+
+5. **Wire the kernel up in the `J_` wrapper.** For each block the
+   wrapper emits: (a) one line per diag term that materialises its
+   inner vector using scipy.sparse (e.g. `_mb0_u0 = p_ref - (B_nr@f) +
+   (G_nr@e)`); (b) a call to `_mut_block_N(...)` passing the inner
+   vectors, base variables, and mapping arrays; (c) an assignment of
+   the returned `data` array into the appropriate slice of the overall
+   Jacobian `_data_`.
+
+   Crucially, each block's **scipy work is capped at one SpMV per diag
+   term** — nothing else in the block touches sparse matrices at
+   runtime. The data for row/col-scale terms comes straight from the
+   pre-baked `_mb_rs_dat_k` arrays.
+
+The net effect on a Newton step is that the Jacobian assembly cost is
+dominated by (i) the constant `inner_J` call for element-wise blocks
+and (ii) a handful of SpMVs for the diag inner vectors. The actual
+mutable-matrix blocks themselves are assembled in
+$\mathcal{O}(\text{nnz})$ vectorised Numba loops — no sparse matrix
+allocation, no sparsity reconstruction, no format conversion.
+
+#### Why not fancy indexing?
+
+An earlier iteration of the pipeline used `expr.tocsr()[[row],[col]]`
+fancy indexing — build the sparse matrix with `sps.diags` and read
+back the nonzero values at the precomputed COO positions. It is
+correct and elegant but slow: scipy has to construct several
+intermediate sparse matrices per step, sum them (with explicit-zero
+elimination), and then perform a linear-scan lookup for each output
+position. On a 30-bus power flow case, each Jacobian call took ≈ 280
+µs. The scatter-add Numba path drops that to ≈ 50 µs while producing
+bit-identical results.
+
+The fallback path still uses fancy indexing, so if you write an
+equation whose Jacobian term structure the analyser doesn't recognise,
+you get *correct* results — just slower. Profile with
+`pytest --durations=10` and look for mutable-matrix blocks lingering
+in the slow path if performance matters.
+
+### Layer 3 — Selective `@njit`
+
+All generated inner loops — `inner_F`, every per-equation
+`inner_F{N}`, `inner_J`, every per-block `inner_J{N}`, and every
+`_mut_block_{N}` — carry `@njit(cache=True)`. Only the `F_` / `J_`
+wrappers remain pure Python; they host the scipy.sparse SpMV
+precomputes, the module-level parameter unpacks, and the final
+`sps.coo_array((data, (row, col)), shape).tocsc()` that packages the
+Jacobian back into a scipy object for the downstream Newton solver.
+
+The selectivity matters: Numba absolutely cannot digest a
+`scipy.sparse.csc_array` argument, which is why the wrappers exist at
+all. Anything that *can* run inside Numba is pushed there, at zero
+syntactic cost to the user — they just write `Mat_Mul(A, x)` and
+`module_printer` figures out the rest.
+
+An important corollary for non-`Mat_Mul` models: if an equation system
+contains **no** `Mat_Mul` at all, the entire precompute / mutable-
+matrix machinery is disabled and `F_` / `J_` collapse back to the
+original pre-0.8 architecture (direct `@njit` on `inner_F` receiving
+only dense vectors and scalar params). Performance on pure
+element-wise models is therefore unchanged by the Mat_Mul rewrite.
+
+### Fallback path
+
+If a Jacobian block contains a term whose shape the symbolic analyser
+does not recognise — for example an unusual nested `Mat_Mul`, a
+non-parameter matrix, or a matrix-valued non-linear expression — that
+single block is handled by a slower but always-correct path:
+
+```python
+data[start:stop] = asarray(
+    (sps.diags(u) + sps.diags(v)@M + ...)
+    .tocsr()[[rows], [cols]]
+).ravel()
+```
+
+This builds the block with scipy.sparse and reads its values at the
+precomputed COO positions. It is $\mathcal{O}(\text{nnz} \log n)$ per
+call instead of the $\mathcal{O}(\text{nnz})$ scatter-add path, but it
+never misses a derivative term. Only the single affected block falls
+back; the rest of the Jacobian still uses the fast path.
+
+If you want to know whether your model is hitting the fallback,
+profile with `pytest --durations=20` or `cProfile` and look for
+`MutableMatJacDataModule` in the traces — its presence in the hot
+`J_()` line indicates a fallback block.
+
+### Performance
+
+Measurements below are per `J_()` call on a 2025 MacBook Air (Apple
+M4), averaged over 5000–10000 iterations.
+
+**Case A — rectangular power flow on MATPOWER `case30`**
+(58 unknowns, 450 Jacobian nonzeros, 6 mutable-matrix blocks, the flow
+has meaningful $G\,e$, $B\,f$, $B\,e$, $G\,f$ combinations):
+
+| Pipeline | `J_()` per call |
+|---|---|
+| Inline mode (lambdify + scipy SpMV) | ≈ 268 µs |
+| Module printer, old `tocsr()[rows, cols]` | ≈ 283 µs |
+| **Module printer, vectorized @njit** | **≈ 50 µs** |
+
+**Case B — DHS hydraulic subproblem on `BarryIsland`**
+(35 unknowns, 1 loop, 1 mutable-matrix block — the loop pressure
+Jacobian contains two col-scale terms
+$L\,\operatorname{diag}(K \odot |m|)$ and
+$L\,\operatorname{diag}(K \odot m \odot \operatorname{sign}(m))$ whose
+scaling vectors are non-trivial expressions of the variable):
+
+| Pipeline | `J_()` per call |
+|---|---|
+| Element-wise inline (one scalar `Eqn` per node + loop) | ≈ 103 µs |
+| Mat_Mul inline (lambdify) | ≈ 45 µs |
+| **Mat_Mul module printer, vectorized @njit** | **≈ 28 µs** |
+
+- **Element-wise vs Mat_Mul inline.** Writing the same hydraulic
+  system as `V @ m - m_inj = 0` plus `L @ (K m |m|) = 0` (two vector
+  equations total) instead of 35 scalar equations cuts inline time by
+  more than half, because lambdify has far fewer expression nodes to
+  walk at runtime.
+- **Inline vs module printer.** Even on a small system (only 79
+  nonzeros), the module printer wins once every mutable-matrix term
+  reaches the vectorised scatter-add path. Here the loop-pressure
+  Jacobian has two col-scale terms whose scaling vectors
+  (``K * |m|`` and ``K * m * sign(m)``) are computed once per `J_`
+  call as dense numpy expressions in the wrapper, then handed to a
+  Numba kernel that does two 10-iteration scatter-add loops. The only
+  remaining overhead is the final `coo_array(...).tocsc()` packing.
+
+Rule of thumb: **module printer wins whenever the mutable-matrix
+blocks successfully match the fast path**; it can lose to inline for
+models that fall through to the fallback (scipy-sparse + fancy
+indexing), or models small enough that the final COO-to-CSC packing
+dominates. Profile with `%timeit mdl.J(y, mdl.p)` on a representative
+iterate if in doubt, and check the generated `num_func.py` for any
+lingering `MutableMatJacDataModule` (= fallback) calls.
+
+The scatter-add path is strictly $\mathcal{O}(\text{nnz})$ in the block
+contents, while the old fancy-indexing path was dominated by the cost
+of constructing the intermediate sparse matrices — so the speed-up
+scales with nnz and with the number of mutable-matrix blocks. For
+models with many rows and few blocks the advantage is small; for
+models with many blocks per variable (such as power flow, with
+distinct $\partial/\partial e$ and $\partial/\partial f$ blocks for
+both $P$ and $Q$ balances) the advantage compounds.
 
 ## API Reference
 

--- a/docs/src/release_notes.md
+++ b/docs/src/release_notes.md
@@ -34,16 +34,38 @@ upgrade — 0.8.0 has a latent miscompilation when two independent
   triggerable param, or a `TimeSeriesParam` — objects Numba cannot
   lower. Pure element-wise models are unaffected.
 
+- **`FormJac` and `JacBlock` agree on the mutable-matrix predicate.**
+  The "is this block a mutable-matrix block?" decision is now made
+  in a single place using the same criterion on both sides —
+  matrix-valued derivative that is not a plain `Para` / `-Para`.
+  Previously `FormJac` additionally required the expression to
+  contain both `Mat_Mul` and `Diag`, while `JacBlock.is_mutable_matrix`
+  did not. The divergence would have let a derivative like
+  `Diag(x)` skip the `SpDiag` perturbation step and produce a
+  shrunken `CooRow` / `CooCol` at a flat start — the downstream
+  scatter-add kernel would then write to fewer output positions
+  than the runtime expected. No known model hit this in practice
+  but the fix closes the corner case.
+
 ### API Changes
 
-- **`Mat_Mul` + triggerable / time-series params now errors out.**
-  Using a `triggerable=True` parameter or a `TimeSeriesParam` in the
-  same equation as `Mat_Mul` raises `NotImplementedError` at
-  `FormJac` / `create_instance` time. Previously the combination
-  silently froze the triggered values inside the generated Jacobian
-  kernel and produced wrong Newton steps once the trigger fired.
-  Users who hit this restriction should rewrite the matrix assembly
-  elementwise.
+- **`Mat_Mul` + triggerable 2-D sparse matrix now errors out.** Using
+  a `triggerable=True` (or `TimeSeriesParam`) 2-D sparse parameter as
+  the **matrix operand** of a `Mat_Mul` raises `NotImplementedError`
+  at `FormJac` / `create_instance` time. The Layer-2 scatter-add
+  Jacobian kernel bakes the matrix's `.data` array into its compiled
+  code at model-build time; a trigger firing at runtime would
+  silently be ignored and the Jacobian would freeze on the initial
+  values while the residual kept evolving. Users who need a
+  triggerable matrix must split the residual and write the affected
+  equation in explicit elementwise form (one scalar `Eqn` per row).
+
+  The check is deliberately narrow: a triggerable *vector* or
+  *scalar* sitting next to a `Mat_Mul`, or used *inside* the vector
+  operand of a `Mat_Mul`, is unaffected and allowed — the `F_` / `J_`
+  wrappers read the current parameter value from `p_` on every
+  Newton step, so no bake-in can happen. `TimeSeriesParam` is always
+  1-D and is therefore always allowed to coexist with `Mat_Mul`.
 
 - **Reserved symbol prefixes `_sz_mm_` and `_sz_mb_`.** Any user
   symbol (`Var`, `Param`, `iVar`, `Para`, ...) whose name starts with
@@ -69,6 +91,26 @@ upgrade — 0.8.0 has a latent miscompilation when two independent
     names actually emitted by the code printer.
   - Explicit note about the `+=` accumulation rule for diagonal
     scatter-add terms.
+  - New explicit list of the cases that push a mutable-matrix
+    block onto the {ref}`fallback path <fallback-path>` — useful
+    when a model is slower than expected and you want to know
+    whether a block is hitting the fast or slow path.
+  - The immutability warning now spells out that the restriction
+    only strictly applies to matrices used in the vectorised
+    `Mat_Mul` fast path (the fallback path re-evaluates the full
+    expression each call and would reflect mutations), but still
+    recommends treating all sparse matrix params as immutable.
+
+### Internal cleanup
+
+- Removed the dead `include_sparse_in_list` parameter from
+  `print_F` / `print_inner_F` / `print_J` / `print_inner_J` and from
+  `_has_sparse_in_param_list`. With the Mat_Mul precompute
+  architecture every caller hard-coded `False` and the parameter was
+  vestigial.
+- Dropped the unused `_var_base_name` / `_var_access_expr` helpers
+  from `mutable_mat_analyzer`; they were leftovers from an earlier
+  draft of `print_inner_J`.
 
 ### Full Changelog
 

--- a/docs/src/release_notes.md
+++ b/docs/src/release_notes.md
@@ -104,23 +104,48 @@ the `Mat_Mul` hot-F path (see Performance below).
 
 ### API Changes
 
-- **`Mat_Mul` + triggerable 2-D sparse matrix now errors out.** Using
-  a `triggerable=True` (or `TimeSeriesParam`) 2-D sparse parameter as
-  the **matrix operand** of a `Mat_Mul` raises `NotImplementedError`
-  at `FormJac` / `create_instance` time. The Layer-2 scatter-add
-  Jacobian kernel bakes the matrix's `.data` array into its compiled
-  code at model-build time; a trigger firing at runtime would
-  silently be ignored and the Jacobian would freeze on the initial
-  values while the residual kept evolving. Users who need a
-  triggerable matrix must split the residual and write the affected
-  equation in explicit elementwise form (one scalar `Eqn` per row).
+- **Time-varying sparse `dim=2` `Param`s are now rejected at
+  construction.** Declaring a `Param(..., dim=2, sparse=True,
+  triggerable=True, ...)` or a `TimeSeriesParam(..., dim=2,
+  sparse=True)` raises `NotImplementedError` at the point of
+  construction, regardless of whether the parameter is ever
+  referenced in an equation.
 
-  The check is deliberately narrow: a triggerable *vector* or
-  *scalar* sitting next to a `Mat_Mul`, or used *inside* the vector
-  operand of a `Mat_Mul`, is unaffected and allowed — the `F_` / `J_`
-  wrappers read the current parameter value from `p_` on every
-  Newton step, so no bake-in can happen. `TimeSeriesParam` is always
-  1-D and is therefore always allowed to coexist with `Mat_Mul`.
+  Every Solverz code path that consumes a sparse `dim=2` `Param`
+  caches its CSC decomposition (`<name>_data`, `<name>_indices`,
+  `<name>_indptr`, `<name>_shape0`) at model-build time: the
+  legacy `MatVecMul` pipeline, the new 0.8.1 `Mat_Mul`
+  `SolCF.csc_matvec` fast path, and the mutable-matrix Jacobian
+  scatter-add kernel all read the frozen flats. A runtime
+  `trigger_fun` firing or a `get_v_t(t)` update simply gets lost,
+  and the Newton iteration either diverges or silently converges
+  to the wrong solution.
+
+  Earlier 0.8.1 drafts narrowed this check to "sparse dim=2
+  time-varying Para used as the matrix operand of a `Mat_Mul`",
+  catching the combination only at `FormJac` time. That was a
+  loophole: legacy `MatVecMul` usage, or any other code path that
+  consumes the CSC flats, slipped through. The 0.8.1 policy
+  closes the loophole by rejecting the shape at the exact line
+  where it is declared — the error message now points at the
+  user's source, not a deep internal.
+
+  The check lives in `ParamBase.__init__` and
+  `TimeSeriesParam.__init__`, with a backstop in
+  `Equations._check_no_timevar_sparse_matrices` (runs on every
+  `FormJac` call) for the edge case where a tainted `Param` was
+  built via `__new__` + attribute assignment, bypassing the
+  `__init__` guard.
+
+  **Allowed alternatives**: triggerable / time-series *vectors*
+  or *scalars* sitting next to a `Mat_Mul`, element-wise
+  formulations where per-row coefficients are 1-D time-varying
+  parameters, and dense `dim=2` parameters (`sparse=False`, which
+  takes the `MutableMatJacDataModule` fallback path that
+  re-evaluates the full block expression on every `J_()` call and
+  tolerates runtime updates). See the
+  {ref}`Restrictions section <restrictions>` of the Matrix
+  Calculus guide for full workarounds.
 
 - **Reserved symbol prefixes `_sz_mm_` and `_sz_mb_`.** Any user
   symbol (`Var`, `Param`, `iVar`, `Para`, ...) whose name starts with

--- a/docs/src/release_notes.md
+++ b/docs/src/release_notes.md
@@ -8,6 +8,61 @@ Hotfix release addressing correctness findings in the 0.8.0 `Mat_Mul`
 mutable-matrix Jacobian code generation. Users of `Mat_Mul` should
 upgrade — 0.8.0 has a latent miscompilation when two independent
 `Diag(...)` terms land on the same `(i,i)` positions (see Bug Fixes).
+The release also brings a large runtime-performance improvement to
+the `Mat_Mul` hot-F path (see Performance below).
+
+### Performance
+
+- **`Mat_Mul` hot F: 4.4× speedup on small networks.** Before 0.8.1
+  every `Mat_Mul(A, v)` precompute executed as a `scipy.sparse` SpMV
+  in the Python `F_` wrapper (`_sz_mm_N = A @ v`). On small systems
+  this was dispatch-bound: each SpMV crossed Python → scipy → C →
+  back and cost ≈ 1.5 µs *per call* of pure overhead, regardless of
+  how little arithmetic the matrix actually had. Eight SpMVs per
+  power-flow `F_()` call added up to ≈ 12 µs of scipy dispatch on
+  case30, compared to well under 1 µs of actual matvec work.
+
+  The 0.8.1 code generator now recognises plain sparse `dim=2`
+  `Para` matrix operands and emits the matvec **inside** `inner_F`
+  using the existing `SolCF.csc_matvec` Numba helper
+  (`Solverz/num_api/custom_function.py`). The CSC decomposition
+  (`<name>_data` / `<name>_indices` / `<name>_indptr` / `<name>_shape0`)
+  that `Solverz/model/basic.py` already emits for every sparse
+  `dim=2` `Param` is the direct input for the helper — no new
+  `setting` entries, no new helper function.
+
+  Case30 power-flow benchmark (per `F_()` call, Apple M4):
+
+  | Formulation | 0.8.1 baseline | **0.8.1 fast path** | Speedup |
+  |---|---:|---:|---:|
+  | `Mat_Mul` (rectangular) | 14.1 µs | **3.23 µs** | **4.4×** |
+  | For-loop (polar) reference | 1.40 µs | 1.11 µs | — |
+
+  The `Mat_Mul` / polar hot-F ratio drops from **10.1× to 2.9×**.
+  `J` call, cold compile, module render, and every other phase
+  are unchanged. The remaining 2.9× gap is the structural cost of
+  8 `SolCF.csc_matvec` calls + 3 sub-function calls + dispatcher in
+  Mat_Mul vs 53 inlined scalar kernels in polar; closing it further
+  would require SpMV fusion or switching to CSR format, neither of
+  which is in this release. See
+  {ref}`When to use (and not use) Mat_Mul <when-to-use-mat_mul>`
+  in the matrix calculus guide for a full decision matrix.
+
+- **Fallback path** — `Mat_Mul` placeholders whose matrix operand is
+  not a plain sparse `Para` (negated matrices `Mat_Mul(-A, x)`,
+  nested matrix expressions, dense `dim=2` params) keep the old
+  scipy SpMV path in the wrapper. They are functionally correct
+  but do not benefit from the fast path; users who hit performance
+  regressions should check whether they can rewrite `-Mat_Mul(A,x)`
+  instead of `Mat_Mul(-A,x)`, or declare matrices with
+  `sparse=True`.
+
+- **`print_F` dead-load cleanup.** With the fast path in place, the
+  `F_` wrapper no longer loads `A = p_["A"]` for sparse `dim=2`
+  matrices that are used *only* as fast-path `Mat_Mul` operands —
+  previously that line was dead but still emitted. The filter
+  inspects each placeholder's `matrix_arg` and only keeps the
+  matrix load if at least one fallback `Mat_Mul` needs it.
 
 ### Bug Fixes
 

--- a/docs/src/release_notes.md
+++ b/docs/src/release_notes.md
@@ -2,6 +2,78 @@
 
 # Release Notes
 
+## 0.8.1
+
+Hotfix release addressing correctness findings in the 0.8.0 `Mat_Mul`
+mutable-matrix Jacobian code generation. Users of `Mat_Mul` should
+upgrade — 0.8.0 has a latent miscompilation when two independent
+`Diag(...)` terms land on the same `(i,i)` positions (see Bug Fixes).
+
+### Bug Fixes
+
+- **Multiple `Diag` terms now accumulate correctly.** Equations whose
+  Jacobians contain two or more independent `Diag` terms sharing
+  output positions — e.g. `x*(A@x) + x*(B@x)` producing
+  `diag(A@x) + diag(B@x) + diag(x)@A + diag(x)@B` — previously had
+  one of the two diagonal contributions silently overwritten in the
+  module-printer path. The scatter-add kernel now uses `+=` for every
+  term, including diag. Inline mode was already correct. Regression
+  test: `test_multi_diag_accumulation`.
+
+- **`Model` no longer crashes on dense `dim=2` parameters.**
+  `model.create_instance()` unconditionally tried to decompose every
+  `dim=2` parameter into sparse CSC flat arrays (`.data`, `.indices`,
+  `.indptr`), which for a dense `ndarray` fed a `memoryview` into
+  `Array` and raised `TypeError: Unsupported array type <class
+  'memoryview'>`. Decomposition is now restricted to
+  `sparse and dim == 2`; dense matrices pass through untouched.
+
+- **Selective `@njit` gating respects sparse parameter content.** The
+  `inner_F` / `inner_J` helpers are now generated without `@njit` when
+  the generated parameter list contains a sparse `dim=2` param, a
+  triggerable param, or a `TimeSeriesParam` — objects Numba cannot
+  lower. Pure element-wise models are unaffected.
+
+### API Changes
+
+- **`Mat_Mul` + triggerable / time-series params now errors out.**
+  Using a `triggerable=True` parameter or a `TimeSeriesParam` in the
+  same equation as `Mat_Mul` raises `NotImplementedError` at
+  `FormJac` / `create_instance` time. Previously the combination
+  silently froze the triggered values inside the generated Jacobian
+  kernel and produced wrong Newton steps once the trigger fired.
+  Users who hit this restriction should rewrite the matrix assembly
+  elementwise.
+
+- **Reserved symbol prefixes `_sz_mm_` and `_sz_mb_`.** Any user
+  symbol (`Var`, `Param`, `iVar`, `Para`, ...) whose name starts with
+  either prefix is rejected at construction time with a `ValueError`.
+  These prefixes are used by the code generator for Mat_Mul precompute
+  helpers and mutable-matrix Jacobian block helpers. The check is
+  bypassed internally via `internal_use=True`.
+
+- **Dense `dim=2` params in `Mat_Mul` emit a one-shot `UserWarning`.**
+  A parameter declared with `dim=2, sparse=False` and used inside a
+  `Mat_Mul` works correctly via the fallback path but forfeits the
+  scatter-add fast path. `FormJac` now warns once per offending
+  parameter to flag the performance cost. See the new
+  {ref}`Restrictions and reserved names <restrictions>` section of
+  the matrix calculus guide for migration guidance.
+
+### Documentation
+
+- Extended {ref}`Matrix-Vector Calculus <matrix_calculus>`:
+  - New {ref}`Restrictions and reserved names <restrictions>` section
+    documenting the three API boundaries introduced in 0.8.1.
+  - Code examples updated to show the `_sz_mm_` / `_sz_mb_` helper
+    names actually emitted by the code printer.
+  - Explicit note about the `+=` accumulation rule for diagonal
+    scatter-add terms.
+
+### Full Changelog
+
+[0.8.0...0.8.1](https://github.com/smallbunnies/Solverz/compare/0.8.0...0.8.1)
+
 ## 0.8.0
 
 ### Highlights

--- a/tests/test_matrix_equation.py
+++ b/tests/test_matrix_equation.py
@@ -247,32 +247,81 @@ def test_triggerable_vector_next_to_matmul_allowed():
     assert J0.shape == (2, 2)
 
 
-def test_triggerable_matrix_in_matmul_errors():
-    """Finding 2 (R1-narrowed): a triggerable 2-D *sparse matrix* used
-    as the matrix operand of ``Mat_Mul`` MUST raise
-    ``NotImplementedError`` at ``FormJac`` time. The Layer-2 kernel
-    would otherwise bake the matrix's ``.data`` into the generated
-    scatter-add loop and keep using the frozen values after a trigger
-    fires — producing wrong Newton steps.
+def test_triggerable_sparse_matrix_rejected_at_construction():
+    """Time-varying sparse ``dim=2`` matrices are unsupported in
+    Solverz: every downstream code path (``MatVecMul``, ``Mat_Mul``
+    fast path, mutable-matrix Jacobian scatter-add) caches the
+    matrix's CSC fields at model-build time, so a runtime trigger
+    update would silently be ignored and produce wrong Newton
+    steps. Construction must fail at the ``Param(...)`` line
+    itself — not deep inside ``FormJac`` — so the error points at
+    the offending declaration in the user's source.
     """
     import pytest
-    import numpy as np
     from scipy.sparse import csc_array
-    m = Model()
-    m.x = Var('x', [0.5, 0.5])
-    m.b = Param('b', [4.0, 5.0])
-    # Triggerable 2-D sparse matrix as Mat_Mul operand — forbidden.
-    m.A = Param('A', csc_array(np.array([[2., 1.], [1., 3.]])),
-                dim=2, sparse=True,
-                triggerable=True, trigger_var=['x'],
-                trigger_fun=lambda x: csc_array(
-                    np.array([[2., 1.], [1., 3.]])))
-    m.eqn = Eqn('f', Mat_Mul(m.A, m.x) - m.b)
-
-    smdl, y0 = m.create_instance()
     with pytest.raises(NotImplementedError,
-                       match=r"triggerable 2-D sparse parameter 'A'"):
-        smdl.FormJac(y0)
+                       match=r"sparse 2-D ``Param``.*triggerable"):
+        Param('A', csc_array(np.array([[2., 1.], [1., 3.]])),
+              dim=2, sparse=True,
+              triggerable=True, trigger_var=['x'],
+              trigger_fun=lambda x: csc_array(
+                  np.array([[2., 1.], [1., 3.]])))
+
+
+def test_timeseries_sparse_matrix_rejected_at_construction():
+    """Same policy for ``TimeSeriesParam``: a sparse ``dim=2``
+    time-series param is rejected at construction, independently
+    of whether it's ever used in a ``Mat_Mul``.
+    """
+    import pytest
+    from Solverz import TimeSeriesParam
+    from scipy.sparse import csc_array
+    I = csc_array(np.eye(2))
+    with pytest.raises(NotImplementedError,
+                       match=r"sparse 2-D ``TimeSeriesParam``"):
+        TimeSeriesParam('A', v_series=[I, I],
+                        time_series=[0.0, 1.0],
+                        dim=2, sparse=True)
+
+
+def test_formjac_backstop_rejects_tainted_triggerable_sparse_param():
+    """Backstop check: even if a triggerable sparse ``dim=2`` Param
+    slips past ``Param.__init__`` (e.g. via ``__new__`` and
+    attribute assignment, or post-hoc flag mutation), the
+    ``FormJac`` backstop ``_check_no_timevar_sparse_matrices`` must
+    still raise ``NotImplementedError``.
+
+    Tested directly at the method level, rather than by trying to
+    coerce a full ``Model`` / ``create_instance`` flow into a
+    tainted state — the intervening ``trigger_param_updater``
+    machinery fights back when ``triggerable`` is flipped after
+    construction, and the point here is that the backstop catches
+    a tainted ``PARAM`` dict regardless of how it got that way.
+    """
+    import pytest
+    from scipy.sparse import csc_array
+    from Solverz.equation.equations import Equations as SymEquations
+
+    # Build a legal Equations-like container and stuff a tainted
+    # Param into its PARAM dict by bypassing ``Param.__init__``.
+    eqs = SymEquations.__new__(SymEquations)
+    eqs.PARAM = {}
+
+    tainted = Param.__new__(Param)
+    tainted.name = 'A'
+    tainted.dim = 2
+    tainted.sparse = True
+    tainted.triggerable = True
+    tainted.trigger_var = None
+    tainted.trigger_fun = None
+    tainted.is_alias = False
+    tainted.dtype = float
+    tainted._ParamBase__v = csc_array(np.eye(2))
+    eqs.PARAM['A'] = tainted
+
+    with pytest.raises(NotImplementedError,
+                       match=r"triggerable sparse ``dim=2`` parameter"):
+        eqs._check_no_timevar_sparse_matrices()
 
 
 def test_dense_dim2_param_warning():
@@ -418,42 +467,16 @@ def test_selective_njit_gating_element_wise_happy_path(tmp_path):
         'Expected @njit on inner_J for pure element-wise model'
 
 
-def test_selective_njit_gating_sparse_triggerable_skips_njit(tmp_path):
-    """Finding 1 (R6.3 negative case): a model whose ``PARAM`` dict
-    contains a sparse triggerable param must NOT put ``@njit`` on
-    ``inner_F`` / ``inner_J`` — Numba cannot digest scipy.sparse
-    arguments, and the gate must fire based on ``PARAM`` content, not
-    solely on equation structure.
-    """
-    from scipy.sparse import csc_array
-    m = Model()
-    m.x = Var('x', [1.0, 1.0])
-    m.a = Param('a', 2.0)
-    # Sparse + triggerable → unconditionally enters param_list via
-    # the ``if not sparse or triggerable`` branch in print_param.
-    m.K = Param('K', csc_array(np.array([[1.0, 0.0], [0.0, 1.0]])),
-                dim=2, sparse=True,
-                triggerable=True, trigger_var=['x'],
-                trigger_fun=lambda x: csc_array(np.diag(x)))
-    # Simple element-wise equation — K is NOT used in the residual,
-    # but it still lands in PARAM and therefore in param_list.
-    m.eqn = Eqn('f', m.a * m.x - 1.0)
-    smdl, y0 = m.create_instance()
-
-    dir_mod = str(tmp_path / 'njit_gated')
-    printer = module_printer(smdl, y0, 'njit_gated_mod',
-                             directory=dir_mod, jit=True)
-    printer.render()
-    num_func_path = os.path.join(dir_mod, 'njit_gated_mod', 'num_func.py')
-    with open(num_func_path) as f:
-        source = f.read()
-    lines = source.split('\n')
-    for i, line in enumerate(lines):
-        if line.startswith('def inner_F(') or line.startswith('def inner_J('):
-            prev = lines[i - 1] if i > 0 else ''
-            assert '@njit' not in prev, (
-                f'Expected NO @njit above {line!r} when PARAM contains '
-                f'a sparse triggerable Param, got prev={prev!r}')
+# NOTE: the 0.8.1 R6.3 negative test (sparse triggerable Param →
+# @njit skipped) has been removed because sparse ``dim=2``
+# triggerable / TimeSeriesParam instances are now rejected at
+# ``Param(...)`` construction time (see
+# ``test_triggerable_sparse_matrix_rejected_at_construction``). Any
+# equation system that previously relied on the @njit gating for
+# a sparse 2-D time-varying param is now a construction error; the
+# ``_has_sparse_in_param_list`` function is still kept as defence
+# in depth for sparse 1-D time-varying params (an edge case that
+# is neither rejected nor common in practice).
 
 
 def test_nested_matmul_smoke(tmp_path):

--- a/tests/test_matrix_equation.py
+++ b/tests/test_matrix_equation.py
@@ -489,3 +489,198 @@ def test_nested_matmul_smoke(tmp_path):
     expected = np.linalg.solve(AB, np.array([3.0, 4.0]))
     np.testing.assert_allclose(sol_inline.y.array, expected, atol=1e-10)
     np.testing.assert_allclose(sol_mod.y.array, expected, atol=1e-10)
+
+
+def test_nested_matmul_outer_fallback_demotes_inner(tmp_path):
+    """Review R2: when the outer of a nested ``Mat_Mul`` cannot hit
+    the fast path (e.g. ``Mat_Mul(-A, Mat_Mul(B, x))`` — the outer
+    matrix is ``-A``, not a bare ``Para``), the inner placeholder
+    must be **demoted** from the fast path to the fallback. The
+    wrapper needs to define ``_sz_mm_0`` (the inner B@x) before the
+    outer ``_sz_mm_1 = (-A) @ _sz_mm_0`` scipy SpMV runs. A classifier
+    that looks only at ``matrix_arg`` leaves ``_sz_mm_0`` on the
+    fast path (B is a bare sparse Para) and the generated wrapper
+    references an undefined local.
+
+    Locks in the dependency-aware classification added after the
+    ``csc_matvec`` review pass.
+    """
+    m = Model()
+    m.x = Var('x', [0.5, 0.5])
+    m.b = Param('b', [3.0, 4.0])
+    m.A = Param('A', [[1.0, 0.5], [0.5, 1.0]], dim=2, sparse=True)
+    m.B = Param('B', [[2.0, 0.0], [0.0, 2.0]], dim=2, sparse=True)
+    # Outer ``-A`` is Mul(-1, A) — not a bare Para — so it falls
+    # back. Inner Mat_Mul(B, x) looks fast in isolation but must be
+    # demoted because the outer fallback references it.
+    m.eqn = Eqn('f', Mat_Mul(-m.A, Mat_Mul(m.B, m.x)) - m.b)
+
+    spf, y0 = m.create_instance()
+
+    # Inline solve (independent correctness reference)
+    mdl_inline = made_numerical(spf, y0, sparse=True)
+    sol_inline = nr_method(mdl_inline, y0)
+
+    # Module solve — this is the path that had the R2 bug. If the
+    # inner placeholder is still fast-path-classified, the wrapper
+    # emits ``_sz_mm_1 = (-A) @ _sz_mm_0`` with ``_sz_mm_0`` never
+    # defined anywhere and ``F_`` raises ``NameError`` on entry.
+    dir_mod = str(tmp_path / 'nested_neg')
+    printer = module_printer(spf, y0, 'nested_neg_mod',
+                             directory=dir_mod, jit=True)
+    printer.render()
+    sys.path.insert(0, dir_mod)
+    from nested_neg_mod import mdl as mdl_mod, y as y_mod
+    sol_mod = nr_method(mdl_mod, y_mod)
+
+    # Analytical: -A @ B @ x = b → x = solve(-AB, b)
+    A = np.array([[1.0, 0.5], [0.5, 1.0]])
+    B = np.array([[2.0, 0.0], [0.0, 2.0]])
+    expected = np.linalg.solve(-A @ B, np.array([3.0, 4.0]))
+    np.testing.assert_allclose(sol_inline.y.array, expected, atol=1e-10)
+    np.testing.assert_allclose(sol_mod.y.array, expected, atol=1e-10)
+
+    # Also inspect the generated source to make sure the wrapper
+    # actually emits both ``_sz_mm_0`` and ``_sz_mm_1`` in
+    # topological order. A regression that re-introduces the R2
+    # bug would skip the ``_sz_mm_0`` assignment.
+    num_func_path = os.path.join(dir_mod, 'nested_neg_mod', 'num_func.py')
+    with open(num_func_path) as f:
+        source = f.read()
+    # The F_ wrapper body must contain both precompute assignments,
+    # and _sz_mm_0 must come before _sz_mm_1 (topological order).
+    f_body_start = source.index('def F_(')
+    f_body_end = source.index('@njit', f_body_start)
+    f_body = source[f_body_start:f_body_end]
+    pos_mm0 = f_body.find('_sz_mm_0 = ')
+    pos_mm1 = f_body.find('_sz_mm_1 = ')
+    assert pos_mm0 >= 0, (
+        'F_ wrapper missing _sz_mm_0 assignment — inner fast path '
+        'was not demoted even though outer fallback depends on it')
+    assert pos_mm1 >= 0, 'F_ wrapper missing _sz_mm_1 assignment'
+    assert pos_mm0 < pos_mm1, (
+        'F_ wrapper emits _sz_mm_1 before _sz_mm_0 — non-topological '
+        'precompute order would break at runtime')
+
+
+def test_print_F_keeps_sparse_params_in_param_list():
+    """Review R1: ``print_F`` must not drop a wrapper assignment for
+    a sparse ``dim=2`` ``Param`` whose name ends up in
+    ``param_list``. ``print_param``'s ``TimeSeriesParam`` branch
+    appends every time-series parameter to ``param_list``
+    unconditionally, so a sparse time-series parameter is (a)
+    loaded in the wrapper as ``A = p_["A"].get_v_t(t)`` and (b)
+    passed through to ``inner_F`` as an argument. A filter that
+    checks only ``dim == 2 and sparse`` would drop the wrapper
+    load but still emit ``inner_F(..., A, ...)``, producing a
+    ``NameError`` on the first call.
+
+    We test the filter directly via ``print_F`` with a constructed
+    ``PARAM`` dict — a sparse 2-D ``TimeSeriesParam`` is hard to
+    build end-to-end through ``Model``/``create_instance`` because
+    its ``v_series`` is forced to 1-D, but the filter logic is
+    what the reviewer flagged and it is fully testable in
+    isolation.
+    """
+    from scipy.sparse import csc_array
+    from Solverz.code_printer.python.module.module_printer import print_F
+    from Solverz.equation.param import TimeSeriesParam
+    from Solverz.utilities.address import Address
+
+    # Construct a 2-D sparse ``TimeSeriesParam`` by reaching past
+    # the ``Array(v_series, dim=1)`` normalisation: set the
+    # attributes the filter actually inspects. This is the minimum
+    # shape the R1 regression reasons about.
+    ts = TimeSeriesParam.__new__(TimeSeriesParam)
+    ts.name = 'A'
+    ts.dim = 2
+    ts.sparse = True
+    ts.is_alias = False
+    ts.triggerable = False
+    ts.trigger_var = None
+    ts.trigger_fun = None
+    ts.dtype = float
+    # Stash a csc_array so the wrapper could actually use it if it
+    # wanted to. The filter never dereferences v, but parse_p might.
+    ts._ParamBase__v = csc_array(np.array([[1.0, 0.0], [0.0, 1.0]]))
+
+    PARAM = {'A': ts}
+    var_addr = Address()
+    var_addr.add('x', 2)
+
+    source = print_F('AE', var_addr, PARAM, nstep=0, precompute_info=None)
+    # Before the R1 fix, the filter would strip the wrapper load
+    # even though ``A`` is still in ``param_list`` — so ``inner_F``
+    # received ``A`` as an argument with no prior definition.
+    assert 'A = p_["A"].get_v_t' in source, (
+        'print_F dropped the TimeSeriesParam wrapper load; inner_F '
+        'will reference an undefined local A')
+    # And ``inner_F`` is still called with A in its argument list
+    # (we care about the symmetry).
+    assert 'inner_F(_F_, x, A)' in source, (
+        'print_F dropped A from the inner_F call site — the filter '
+        'is now too aggressive in the other direction')
+
+
+def test_matmul_three_arg_operand_falls_back(tmp_path):
+    """Review R3: ``Mat_Mul(A, B, x)`` — Solverz allows 3+-argument
+    ``Mat_Mul`` nodes, and ``extract_matmuls`` folds them into a
+    single placeholder with ``matrix_arg = A`` and
+    ``operand_arg = Mat_Mul(B, x)`` (the fresh inner ``Mat_Mul`` is
+    *not* re-walked). A classifier that looks only at ``matrix_arg``
+    would route this into the ``SolCF.csc_matvec`` fast path and
+    emit a call whose operand is ``B @ x`` — but ``B`` is a sparse
+    ``dim=2`` ``Para``, not available inside ``inner_F`` by name,
+    so the generated code would fail.
+
+    The fix is the ``_shape_is_fast`` operand check: fast path
+    requires the operand to contain neither ``Mat_Mul`` nodes nor
+    sparse ``dim=2`` ``Para`` references.
+    """
+    m = Model()
+    m.x = Var('x', [0.5, 0.5])
+    m.b = Param('b', [3.0, 4.0])
+    m.A = Param('A', [[1.0, 0.5], [0.5, 1.0]], dim=2, sparse=True)
+    m.B = Param('B', [[2.0, 0.0], [0.0, 2.0]], dim=2, sparse=True)
+    # 3-arg Mat_Mul: A @ B @ x
+    m.eqn = Eqn('f', Mat_Mul(m.A, m.B, m.x) - m.b)
+
+    spf, y0 = m.create_instance()
+    mdl_inline = made_numerical(spf, y0, sparse=True)
+    sol_inline = nr_method(mdl_inline, y0)
+
+    dir_mod = str(tmp_path / 'three_arg')
+    printer = module_printer(spf, y0, 'three_arg_mod',
+                             directory=dir_mod, jit=True)
+    printer.render()
+    sys.path.insert(0, dir_mod)
+    from three_arg_mod import mdl as mdl_mod, y as y_mod
+    sol_mod = nr_method(mdl_mod, y_mod)
+
+    A = np.array([[1.0, 0.5], [0.5, 1.0]])
+    B = np.array([[2.0, 0.0], [0.0, 2.0]])
+    expected = np.linalg.solve(A @ B, np.array([3.0, 4.0]))
+    np.testing.assert_allclose(sol_inline.y.array, expected, atol=1e-10)
+    np.testing.assert_allclose(sol_mod.y.array, expected, atol=1e-10)
+
+    # The generated F_ wrapper must keep B loaded (it appears in the
+    # fallback operand) and must NOT invoke ``SolCF.csc_matvec`` with
+    # a ``(B@x)`` operand — a regression would do either.
+    num_func_path = os.path.join(dir_mod, 'three_arg_mod', 'num_func.py')
+    with open(num_func_path) as f:
+        source = f.read()
+    f_body_start = source.index('def F_(')
+    f_body_end = source.index('@njit', f_body_start)
+    f_body = source[f_body_start:f_body_end]
+    assert 'B = p_["B"]' in f_body, (
+        'F_ wrapper filter removed B load even though B is needed by '
+        'the fallback Mat_Mul(A, B, x) evaluation')
+    # And check that the csc_matvec fast path is NOT used for this
+    # placeholder — a regression would emit
+    # ``SolCF.csc_matvec(A_data, ..., (B@x))`` inside inner_F.
+    inner_body_start = source.index('def inner_F(')
+    inner_body_end = source.index('def inner_F0', inner_body_start)
+    inner_body = source[inner_body_start:inner_body_end]
+    assert 'SolCF.csc_matvec' not in inner_body, (
+        'inner_F routed a Mat_Mul(A, B, x) placeholder through the '
+        'csc_matvec fast path — operand is not a clean vector')

--- a/tests/test_matrix_equation.py
+++ b/tests/test_matrix_equation.py
@@ -1,7 +1,13 @@
+import copy
+import os
+import shutil
+import sys
 import warnings
 
 import numpy as np
-from Solverz import MatVecMul, Mat_Mul, Var, Param, made_numerical, Model, Eqn, nr_method
+import scipy.sparse.linalg
+from Solverz import (MatVecMul, Mat_Mul, Var, Param, made_numerical, Model, Eqn,
+                     nr_method, module_printer)
 
 
 # %%
@@ -90,3 +96,169 @@ def test_mat_mul_nonlinear():
 
     sol = nr_method(mdl, y0)
     np.testing.assert_allclose(sol.y.array, np.array([1.0, 1.0]), atol=1e-5)
+
+
+def _build_mutable_matrix_model():
+    """x * (A@x) - b = 0: Jacobian = diag(A@x) + diag(x)@A (mutable matrix)."""
+    m = Model()
+    m.x = Var('x', [0.5, 0.5])
+    m.A = Param('A', [[2, 1], [1, 3]], dim=2, sparse=True)
+    m.b = Param('b', [4.0, 5.0])
+    m.eqn = Eqn('f', m.x * Mat_Mul(m.A, m.x) - m.b)
+    return m
+
+
+def test_mat_mul_mutable_jac(tmp_path):
+    """Mutable matrix Jacobian: inline, module (jit=False), module (jit=True)
+    must produce identical Jacobians at every Newton step.
+    """
+    m = _build_mutable_matrix_model()
+    spf, y0 = m.create_instance()
+
+    # --- 1. Inline ---
+    mdl_inline = made_numerical(spf, y0, sparse=True)
+
+    # --- 2. Module (jit=False) ---
+    dir_nojit = str(tmp_path / 'nojit')
+    printer = module_printer(spf, y0, 'mut_nojit', directory=dir_nojit, jit=False)
+    printer.render()
+    sys.path.insert(0, dir_nojit)
+    from mut_nojit import mdl as mdl_mod, y as y_mod
+
+    # --- 3. Module (jit=True) ---
+    dir_jit = str(tmp_path / 'jit')
+    printer_jit = module_printer(spf, y0, 'mut_jit', directory=dir_jit, jit=True)
+    printer_jit.render()
+    sys.path.insert(0, dir_jit)
+    from mut_jit import mdl as mdl_jit, y as y_jit
+
+    # --- Compare Jacobian at each Newton step (drive iteration via inline) ---
+    y_test = copy.deepcopy(y0)
+    for step in range(6):
+        J_i = mdl_inline.J(y_test, mdl_inline.p)
+        J_m = mdl_mod.J(y_test, mdl_mod.p)
+        J_j = mdl_jit.J(y_test, mdl_jit.p)
+        np.testing.assert_allclose(
+            J_i.toarray(), J_m.toarray(), atol=1e-12,
+            err_msg=f"module(jit=False) J mismatch at step {step}")
+        np.testing.assert_allclose(
+            J_i.toarray(), J_j.toarray(), atol=1e-12,
+            err_msg=f"module(jit=True) J mismatch at step {step}")
+        F_val = mdl_inline.F(y_test, mdl_inline.p)
+        dy = scipy.sparse.linalg.spsolve(J_i, -F_val)
+        y_test.array[:] = y_test.array + dy
+
+    # --- Three modes must converge to the same solution ---
+    sol_inline = nr_method(mdl_inline, y0)
+    sol_mod = nr_method(mdl_mod, y_mod)
+    sol_jit = nr_method(mdl_jit, y_jit)
+    np.testing.assert_allclose(sol_inline.y.array, sol_mod.y.array, atol=1e-10)
+    np.testing.assert_allclose(sol_inline.y.array, sol_jit.y.array, atol=1e-10)
+
+
+# ---- Regression tests for review findings ----
+
+def test_multi_diag_accumulation(tmp_path):
+    """Finding 4: multiple independent ``Diag(...)`` terms must
+    accumulate on the diagonal, not overwrite. The derivative of
+    ``x*(A@x) + x*(B@x) - b`` w.r.t. ``x`` is
+    ``diag(A@x) + diag(x)@A + diag(B@x) + diag(x)@B`` — two diag
+    terms both land on ``(i,i)`` positions and their values must sum.
+    """
+    m = Model()
+    m.x = Var('x', [0.5, 0.5])
+    m.A = Param('A', [[2, 1], [1, 3]], dim=2, sparse=True)
+    m.b = Param('b', [4.0, 5.0])
+    m.B = Param('B', [[1.5, 0.5], [0.5, 2.0]], dim=2, sparse=True)
+    m.eqn = Eqn('f', m.x * Mat_Mul(m.A, m.x) + m.x * Mat_Mul(m.B, m.x) - m.b)
+
+    smdl, y0 = m.create_instance()
+    mdl_inline = made_numerical(smdl, y0, sparse=True)
+
+    dir_mod = str(tmp_path / 'multi_diag_mod')
+    printer = module_printer(smdl, y0, 'multi_diag_mod',
+                             directory=dir_mod, jit=True)
+    printer.render()
+    sys.path.insert(0, dir_mod)
+    import importlib
+    if 'multi_diag_mod' in sys.modules:
+        del sys.modules['multi_diag_mod']
+    mod = importlib.import_module('multi_diag_mod')
+    mdl_mod = mod.mdl
+    y_mod = mod.y
+
+    # Drive by a non-trivial iterate so every diag term has a distinct,
+    # non-zero value at (i,i). The bug manifests as module J missing
+    # one of the diagonal contributions.
+    rng = np.random.default_rng(20260413)
+    y_seed = rng.uniform(0.5, 1.5, size=y0.array.shape[0])
+    y_test = copy.deepcopy(y0)
+    y_test.array[:] = y_seed
+    y_test_mod = copy.deepcopy(y_mod)
+    y_test_mod.array[:] = y_seed
+    J_i = mdl_inline.J(y_test, mdl_inline.p)
+    J_m = mdl_mod.J(y_test_mod, mdl_mod.p)
+    np.testing.assert_allclose(
+        J_i.toarray(), J_m.toarray(), rtol=1e-10, atol=1e-12,
+        err_msg='module J misses accumulation across multiple Diag terms')
+
+
+def test_reserved_prefix_rejected():
+    """Findings 5,6: user symbols starting with reserved internal
+    prefixes must be rejected at construction time so the code
+    generator can freely emit helper names of the form
+    ``_sz_mm_<int>`` and ``_sz_mb_<int>_...`` without shadowing."""
+    import pytest
+    with pytest.raises(ValueError, match='reserved internal prefix'):
+        Var('_sz_mm_0', [1.0])
+    with pytest.raises(ValueError, match='reserved internal prefix'):
+        Var('_sz_mb_0_u0', [1.0])
+    with pytest.raises(ValueError, match='reserved internal prefix'):
+        Param('_sz_mm_42', [1.0])
+
+
+def test_triggerable_param_in_matmul_errors():
+    """Finding 2: a triggerable parameter used in the same equation as
+    ``Mat_Mul`` must raise ``NotImplementedError`` at ``FormJac`` /
+    ``create_instance`` time. Silently freezing the triggered values
+    would lead to wrong Newton steps once the trigger fires.
+    """
+    import pytest
+    m = Model()
+    m.x = Var('x', [0.5, 0.5])
+    m.b = Param('b', [4.0, 5.0])
+    # A triggerable param in the SAME equation as Mat_Mul.
+    m.K = Param('K', [1.0, 1.0], triggerable=True,
+                trigger_var=['x'], trigger_fun=lambda x: 2 * x)
+    m.A = Param('A', [[2, 1], [1, 3]], dim=2, sparse=True)
+    m.eqn = Eqn('f', m.K * m.x + Mat_Mul(m.A, m.x) - m.b)
+
+    smdl, _ = m.create_instance()
+    from Solverz.variable.variables import Vars
+    from Solverz.utilities.address import Address
+    # Reuse the existing y0 from create_instance
+    _, y0 = m.create_instance()
+    with pytest.raises(NotImplementedError, match='Mat_Mul'):
+        smdl.FormJac(y0)
+
+
+def test_dense_dim2_param_warning():
+    """Finding 3: dense ``dim=2`` parameters used in Mat_Mul must
+    produce a warning pointing at the performance cost. They should
+    still work correctly (via the fallback path)."""
+    m = Model()
+    m.x = Var('x', [0.5, 0.5])
+    m.b = Param('b', [4.0, 5.0])
+    m.A = Param('A', np.array([[2.0, 1.0], [1.0, 3.0]]),
+                dim=2, sparse=False)
+    m.eqn = Eqn('f', m.x * Mat_Mul(m.A, m.x) - m.b)
+
+    smdl, y0 = m.create_instance()
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        smdl.FormJac(y0)
+        dense_warnings = [x for x in w
+                          if issubclass(x.category, UserWarning)
+                          and 'dense 2-D' in str(x.message)]
+        assert len(dense_warnings) >= 1, \
+            'expected a UserWarning about dense dim=2 in Mat_Mul'

--- a/tests/test_matrix_equation.py
+++ b/tests/test_matrix_equation.py
@@ -217,28 +217,61 @@ def test_reserved_prefix_rejected():
         Param('_sz_mm_42', [1.0])
 
 
-def test_triggerable_param_in_matmul_errors():
-    """Finding 2: a triggerable parameter used in the same equation as
-    ``Mat_Mul`` must raise ``NotImplementedError`` at ``FormJac`` /
-    ``create_instance`` time. Silently freezing the triggered values
-    would lead to wrong Newton steps once the trigger fires.
+def test_triggerable_vector_next_to_matmul_allowed():
+    """Finding 2 (narrowed in review pass R1): a triggerable *vector*
+    parameter sitting next to a ``Mat_Mul`` — but **not** inside its
+    matrix operand — must be allowed. The vector's current value is
+    read from ``p_`` on every Newton step, so the Layer-2 scatter-add
+    cache never sees a stale copy of it. Rejecting this case was the
+    original R1 complaint.
     """
-    import pytest
+    import scipy.sparse.linalg
     m = Model()
     m.x = Var('x', [0.5, 0.5])
-    m.b = Param('b', [4.0, 5.0])
-    # A triggerable param in the SAME equation as Mat_Mul.
+    m.b = Param('b', [5.0, 6.0])
     m.K = Param('K', [1.0, 1.0], triggerable=True,
                 trigger_var=['x'], trigger_fun=lambda x: 2 * x)
     m.A = Param('A', [[2, 1], [1, 3]], dim=2, sparse=True)
     m.eqn = Eqn('f', m.K * m.x + Mat_Mul(m.A, m.x) - m.b)
 
-    smdl, _ = m.create_instance()
-    from Solverz.variable.variables import Vars
-    from Solverz.utilities.address import Address
-    # Reuse the existing y0 from create_instance
-    _, y0 = m.create_instance()
-    with pytest.raises(NotImplementedError, match='Mat_Mul'):
+    smdl, y0 = m.create_instance()
+    # The narrow check must NOT fire for a triggerable scalar vector.
+    smdl.FormJac(y0)
+    mdl = made_numerical(smdl, y0, sparse=True)
+    # And the model must still compute a correct Newton step. Only
+    # sanity-check the residual at y0 (not convergence, since the
+    # triggerable term has no dK/dx in the analytical Jacobian).
+    F0 = mdl.F(y0, mdl.p)
+    J0 = mdl.J(y0, mdl.p)
+    assert F0.shape == (2,)
+    assert J0.shape == (2, 2)
+
+
+def test_triggerable_matrix_in_matmul_errors():
+    """Finding 2 (R1-narrowed): a triggerable 2-D *sparse matrix* used
+    as the matrix operand of ``Mat_Mul`` MUST raise
+    ``NotImplementedError`` at ``FormJac`` time. The Layer-2 kernel
+    would otherwise bake the matrix's ``.data`` into the generated
+    scatter-add loop and keep using the frozen values after a trigger
+    fires — producing wrong Newton steps.
+    """
+    import pytest
+    import numpy as np
+    from scipy.sparse import csc_array
+    m = Model()
+    m.x = Var('x', [0.5, 0.5])
+    m.b = Param('b', [4.0, 5.0])
+    # Triggerable 2-D sparse matrix as Mat_Mul operand — forbidden.
+    m.A = Param('A', csc_array(np.array([[2., 1.], [1., 3.]])),
+                dim=2, sparse=True,
+                triggerable=True, trigger_var=['x'],
+                trigger_fun=lambda x: csc_array(
+                    np.array([[2., 1.], [1., 3.]])))
+    m.eqn = Eqn('f', Mat_Mul(m.A, m.x) - m.b)
+
+    smdl, y0 = m.create_instance()
+    with pytest.raises(NotImplementedError,
+                       match=r"triggerable 2-D sparse parameter 'A'"):
         smdl.FormJac(y0)
 
 
@@ -262,3 +295,197 @@ def test_dense_dim2_param_warning():
                           and 'dense 2-D' in str(x.message)]
         assert len(dense_warnings) >= 1, \
             'expected a UserWarning about dense dim=2 in Mat_Mul'
+
+
+def test_dense_dim2_param_jacobian_numerical(tmp_path):
+    """Finding 3 (R6.1): dense ``dim=2`` ``Param(sparse=False)`` must
+    not just warn — it must produce a *numerically correct* Jacobian
+    via the ``MutableMatJacDataModule`` fallback path. Inline mode
+    already works (it always re-evaluates the expression); the
+    regression risk is the module printer, which until the R1 fix
+    for the dense-vs-sparse decomposition would crash or silently
+    mis-index the fallback. Compare the two paths block-for-block.
+    """
+    m = Model()
+    m.x = Var('x', [0.5, 0.5])
+    m.b = Param('b', [4.0, 5.0])
+    m.A = Param('A', np.array([[2.0, 1.0], [1.0, 3.0]]),
+                dim=2, sparse=False)
+    m.eqn = Eqn('f', m.x * Mat_Mul(m.A, m.x) - m.b)
+
+    spf, y0 = m.create_instance()
+
+    # --- 1. Inline ---
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', UserWarning)
+        mdl_inline = made_numerical(spf, y0, sparse=True)
+
+    # --- 2. Module (jit=True) ---
+    dir_mod = str(tmp_path / 'dense_mat')
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', UserWarning)
+        printer = module_printer(spf, y0, 'dense_mat_mod',
+                                 directory=dir_mod, jit=True)
+        printer.render()
+    sys.path.insert(0, dir_mod)
+    from dense_mat_mod import mdl as mdl_mod, y as y_mod
+
+    # Drive by a non-trivial iterate so every block gets a distinct
+    # numeric value. 5 steps is plenty for NR on 2 unknowns.
+    y_test = copy.deepcopy(y0)
+    y_test_mod = copy.deepcopy(y_mod)
+    rng = np.random.default_rng(20260413)
+    seed = rng.uniform(0.5, 1.5, size=y0.array.shape[0])
+    y_test.array[:] = seed
+    y_test_mod.array[:] = seed
+    for step in range(5):
+        J_i = mdl_inline.J(y_test, mdl_inline.p)
+        J_m = mdl_mod.J(y_test_mod, mdl_mod.p)
+        np.testing.assert_allclose(
+            J_i.toarray(), J_m.toarray(), rtol=1e-10, atol=1e-12,
+            err_msg=f'dense dim=2 fallback J mismatch at step {step}')
+        F_val = mdl_inline.F(y_test, mdl_inline.p)
+        dy = scipy.sparse.linalg.spsolve(J_i, -F_val)
+        y_test.array[:] = y_test.array + dy
+        y_test_mod.array[:] = y_test_mod.array + dy
+
+
+def test_timeseries_param_next_to_matmul_allowed():
+    """Finding 2 / R1 (R6.2): a ``TimeSeriesParam`` (always 1-D) can
+    never be a ``Mat_Mul`` matrix operand, so the narrow R1
+    triggerable check never fires for it. A time-series scalar
+    sitting next to a ``Mat_Mul`` must therefore be allowed to build
+    and the J_ wrapper must be able to compute F and J without error.
+    Locks in that R1's narrowing also covers TimeSeriesParam.
+    """
+    from Solverz import TimeSeriesParam
+    m = Model()
+    m.x = Var('x', [0.5, 0.5])
+    m.b = Param('b', [5.0, 6.0])
+    # Scalar-valued time series — 1-D is the only shape TimeSeriesParam
+    # supports, which is also exactly why R1 narrowing is safe for it.
+    m.t_scale = TimeSeriesParam('t_scale',
+                                v_series=[1.0, 2.0],
+                                time_series=[0.0, 1.0])
+    m.A = Param('A', [[2, 1], [1, 3]], dim=2, sparse=True)
+    # TimeSeriesParam modulates the forcing term, not the variable
+    # being differentiated. This keeps the mutable-matrix Jacobian
+    # independent of t_scale while still making t_scale a free symbol
+    # of an equation that also contains Mat_Mul — exactly the scenario
+    # the narrow R1 check is meant to accept.
+    m.eqn = Eqn('f', Mat_Mul(m.A, m.x) - m.t_scale * m.b)
+
+    smdl, y0 = m.create_instance()
+    # The sole R1 assertion: the narrow check must NOT reject a
+    # TimeSeriesParam that sits in a Mat_Mul equation as long as it
+    # isn't the Mat_Mul matrix operand (which TimeSeriesParam can
+    # never be anyway — it's 1-D only). Downstream AE evaluation of
+    # TimeSeriesParam needs a ``t`` in the wrapper signature that
+    # plain AE models don't expose; that's orthogonal to R1 and is
+    # intentionally not exercised here.
+    smdl.FormJac(y0)
+    # The Jacobian block for ∂f/∂x is just ``A`` (constant), so we
+    # can inspect it structurally without calling F_ / J_.
+    assert len(smdl.jac.blocks) == 1
+    [jbs_row] = smdl.jac.blocks.values()
+    assert all(jb.DeriType == 'matrix' and not jb.is_mutable_matrix
+               for jb in jbs_row.values())
+
+
+def test_selective_njit_gating_element_wise_happy_path(tmp_path):
+    """Finding 1 (R6.3 positive case): a pure element-wise model with
+    NO sparse params must still produce ``@njit``-decorated ``inner_F``
+    / ``inner_J``. This locks in that the selective gating in
+    ``_has_sparse_in_param_list`` does not accidentally strip @njit
+    from the happy path.
+    """
+    m = Model()
+    m.x = Var('x', [1.0, 1.0])
+    m.a = Param('a', 2.0)
+    m.eqn = Eqn('f', m.a * m.x - 1.0)
+    smdl, y0 = m.create_instance()
+
+    dir_mod = str(tmp_path / 'njit_happy')
+    printer = module_printer(smdl, y0, 'njit_happy_mod',
+                             directory=dir_mod, jit=True)
+    printer.render()
+    num_func_path = os.path.join(dir_mod, 'njit_happy_mod', 'num_func.py')
+    with open(num_func_path) as f:
+        source = f.read()
+    assert '@njit(cache=True)\ndef inner_F(' in source, \
+        'Expected @njit on inner_F for pure element-wise model'
+    assert '@njit(cache=True)\ndef inner_J(' in source, \
+        'Expected @njit on inner_J for pure element-wise model'
+
+
+def test_selective_njit_gating_sparse_triggerable_skips_njit(tmp_path):
+    """Finding 1 (R6.3 negative case): a model whose ``PARAM`` dict
+    contains a sparse triggerable param must NOT put ``@njit`` on
+    ``inner_F`` / ``inner_J`` — Numba cannot digest scipy.sparse
+    arguments, and the gate must fire based on ``PARAM`` content, not
+    solely on equation structure.
+    """
+    from scipy.sparse import csc_array
+    m = Model()
+    m.x = Var('x', [1.0, 1.0])
+    m.a = Param('a', 2.0)
+    # Sparse + triggerable → unconditionally enters param_list via
+    # the ``if not sparse or triggerable`` branch in print_param.
+    m.K = Param('K', csc_array(np.array([[1.0, 0.0], [0.0, 1.0]])),
+                dim=2, sparse=True,
+                triggerable=True, trigger_var=['x'],
+                trigger_fun=lambda x: csc_array(np.diag(x)))
+    # Simple element-wise equation — K is NOT used in the residual,
+    # but it still lands in PARAM and therefore in param_list.
+    m.eqn = Eqn('f', m.a * m.x - 1.0)
+    smdl, y0 = m.create_instance()
+
+    dir_mod = str(tmp_path / 'njit_gated')
+    printer = module_printer(smdl, y0, 'njit_gated_mod',
+                             directory=dir_mod, jit=True)
+    printer.render()
+    num_func_path = os.path.join(dir_mod, 'njit_gated_mod', 'num_func.py')
+    with open(num_func_path) as f:
+        source = f.read()
+    lines = source.split('\n')
+    for i, line in enumerate(lines):
+        if line.startswith('def inner_F(') or line.startswith('def inner_J('):
+            prev = lines[i - 1] if i > 0 else ''
+            assert '@njit' not in prev, (
+                f'Expected NO @njit above {line!r} when PARAM contains '
+                f'a sparse triggerable Param, got prev={prev!r}')
+
+
+def test_nested_matmul_smoke(tmp_path):
+    """R6.4: ``Mat_Mul(A, Mat_Mul(B, x))`` — nested Mat_Mul — must
+    render (the ``extract_matmuls`` helper creates one placeholder
+    per nested level) and solve to the analytical solution.
+    """
+    m = Model()
+    m.x = Var('x', [0.5, 0.5])
+    m.b = Param('b', [3.0, 4.0])
+    m.A = Param('A', [[1.0, 0.5], [0.5, 1.0]], dim=2, sparse=True)
+    m.B = Param('B', [[2.0, 0.0], [0.0, 2.0]], dim=2, sparse=True)
+    # f = A @ B @ x - b
+    m.eqn = Eqn('f', Mat_Mul(m.A, Mat_Mul(m.B, m.x)) - m.b)
+
+    spf, y0 = m.create_instance()
+
+    # Inline solve
+    mdl_inline = made_numerical(spf, y0, sparse=True)
+    sol_inline = nr_method(mdl_inline, y0)
+
+    # Module solve (exercise the precompute deduplication + rendering)
+    dir_mod = str(tmp_path / 'nested_mm')
+    printer = module_printer(spf, y0, 'nested_mm_mod',
+                             directory=dir_mod, jit=True)
+    printer.render()
+    sys.path.insert(0, dir_mod)
+    from nested_mm_mod import mdl as mdl_mod, y as y_mod
+    sol_mod = nr_method(mdl_mod, y_mod)
+
+    # Analytical: AB @ x = b → x = solve(AB, b)
+    AB = np.array([[1.0, 0.5], [0.5, 1.0]]) @ np.array([[2.0, 0.0], [0.0, 2.0]])
+    expected = np.linalg.solve(AB, np.array([3.0, 4.0]))
+    np.testing.assert_allclose(sol_inline.y.array, expected, atol=1e-10)
+    np.testing.assert_allclose(sol_mod.y.array, expected, atol=1e-10)


### PR DESCRIPTION
## Summary

0.8.1 hotfix for the `Mat_Mul` / mutable-matrix Jacobian code generation pipeline. Contains correctness fixes, a hot-F performance rewrite, and a policy change on time-varying sparse matrices. No new features; no breaking changes for well-formed 0.8.0 models.

Full release notes: [`docs/src/release_notes.md`](docs/src/release_notes.md) — the `## 0.8.1` section.

### Correctness fixes

- **Multiple `Diag` terms now accumulate** in the module-printer path (`x*(A@x) + x*(B@x)` kind of expressions no longer silently drop one of the diagonal contributions). Inline mode was already correct.
- **Dense `dim=2` params no longer crash `create_instance`** with `memoryview` TypeError.
- **Selective `@njit` gating** correctly skips `@njit` when `param_list` contains sparse TimeSeriesParam / triggerable params.
- **`FormJac` and `JacBlock`** now agree on the mutable-matrix predicate (no more flat-start `Diag(x)` shrunken-pattern corner case).
- **Dependency-aware `Mat_Mul` fast-path classifier**: nested `Mat_Mul(-A, Mat_Mul(B, x))`, 3-argument `Mat_Mul(A, B, x)`, and sparse-param wrapper loads for `TimeSeriesParam` are all handled correctly. Addresses three P2 regressions from a post-commit review (R1, R2, R3 in the review notes).

### Performance

- **`Mat_Mul` hot F: ~4.4× speedup** on small networks (case30 hot F 14.1 µs → 3.2 µs). The matvec now runs inside `inner_F` via the existing `SolCF.csc_matvec` Numba helper instead of a scipy SpMV in the Python `F_` wrapper. No new code paths, no new setting entries — reuses the CSC decomposition (`<name>_data`/`_indices`/`_indptr`/`_shape0`) that `model/basic.py` already emits. Cold compile and J cost are unchanged.
- **`Mat_Mul`/polar hot-F ratio** drops from ~10× to ~2.9× on case30. For any network ≳ 60 unknowns the gap narrows further or flips; Mat_Mul compile-time wins (20–40×) were already dominant in any iterative workflow.

### API changes

- **`Mat_Mul` + triggerable / time-series 2-D sparse matrix is now rejected at `Param(...)` construction time** (previously at `FormJac` time, and previously only when used as a `Mat_Mul` matrix operand). Every downstream Solverz code path — legacy `MatVecMul`, 0.8.1 `Mat_Mul` fast path, mutable-matrix Jacobian scatter-add — caches the sparse matrix's CSC fields at model-build time, so a runtime trigger update is guaranteed to be lost silently. The check lives in `ParamBase.__init__` / `TimeSeriesParam.__init__`, with a backstop in `Equations._check_no_timevar_sparse_matrices`.

  Triggerable / time-series **vectors** sitting next to a `Mat_Mul` are unaffected and allowed — only the `dim=2, sparse=True, triggerable/TimeSeries` combination is rejected.

- **Reserved symbol prefixes `_sz_mm_` and `_sz_mb_`**: user symbols starting with either prefix are rejected at construction. The code generator uses both prefixes for internal helpers.

- **`MatVecMul` is still deprecated** (no change from 0.8.0).

### Internal cleanup

- Dropped the dead `include_sparse_in_list` parameter from `print_F` / `print_inner_F` / `print_J` / `print_inner_J` and the now-dead `_var_base_name` / `_var_access_expr` helpers in `mutable_mat_analyzer`.

### Documentation

- Extended `docs/src/matrix_calculus.md`:
  - New `Restrictions and reserved names` section covering the API boundaries
  - New `When to use (and not use) Mat_Mul` decision matrix with the known case30-scale hot-F regression
  - Updated Layer 1 section describing the new `SolCF.csc_matvec` fast path
  - Explicit enumeration of fallback cases (negated matrices, nested Mat_Mul, 3-arg Mat_Mul, dense dim=2)
- 0.8.1 release notes with the same coverage.

## Test plan

- [x] Full local Solverz-dev test suite: 103 passed
- [x] Local Solverz-Cookbook tests (`heat_flow` + `pf_jac`): 8 passed
- [ ] CI: `built_in_tests` on Windows × macOS × Python 3.10/3.11/3.12
- [ ] CI: `tests_in_museum` — cross-repo SolMuseum compatibility check
- [ ] CI: `tests_in_cookbook` — cross-repo cookbook compatibility check
- [ ] Tag `0.8.1` after merge → `publish-to-pypi` workflow runs automatically

## Regression tests added

- `test_multi_diag_accumulation` (F4)
- `test_reserved_prefix_rejected` (F5, F6)
- `test_dense_dim2_param_warning` + `test_dense_dim2_param_jacobian_numerical` (F3)
- `test_triggerable_vector_next_to_matmul_allowed` (R1-narrowed)
- `test_triggerable_sparse_matrix_rejected_at_construction` (broadened policy)
- `test_timeseries_sparse_matrix_rejected_at_construction` (broadened policy)
- `test_formjac_backstop_rejects_tainted_triggerable_sparse_param` (backstop)
- `test_timeseries_param_next_to_matmul_allowed`
- `test_nested_matmul_smoke` (R6.4)
- `test_nested_matmul_outer_fallback_demotes_inner` (2nd-pass review R2)
- `test_matmul_three_arg_operand_falls_back` (2nd-pass review R3)
- `test_print_F_keeps_sparse_params_in_param_list` (2nd-pass review R1)
- `test_selective_njit_gating_element_wise_happy_path`

🤖 Generated with [Claude Code](https://claude.com/claude-code)