### PR TITLE
ci: provision IPOPT in tests_in_museum job

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -53,6 +53,17 @@ jobs:
         repository: 'smallbunnies/SolMuseum'
         ref: 'main'
 
+    - name: Install IPOPT
+      shell: pwsh
+      env:
+        IPOPT_VERSION: "3.14.12"
+      run: |
+        $url = "https://github.com/coin-or/Ipopt/releases/download/releases%2F$env:IPOPT_VERSION/Ipopt-$env:IPOPT_VERSION-win64-msvs2019-md.zip"
+        Invoke-WebRequest -Uri $url -OutFile Ipopt.zip
+        Expand-Archive -Path Ipopt.zip -DestinationPath .
+        $ipoptPath = "$pwd\Ipopt-$env:IPOPT_VERSION-win64-msvs2019-md\bin"
+        echo "$ipoptPath" >> $env:GITHUB_PATH
+
     - name: Install uv
       uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57
       with:


### PR DESCRIPTION
tests_in_museum checks out SolMuseum main, whose gas/broken-pipe tests need ipopt (via SolUtil.GasFlow). The job never installed ipopt — mirror the proven IPOPT step from tests_in_cookbook so the publish gate can pass. Unblocks the upcoming 0.10.0 tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)