### PR TITLE
fix: generated modules with provenance docstrings fail to import on Windows

### DIFF
--- a/Solverz/code_printer/python/module/module_generator.py
+++ b/Solverz/code_printer/python/module/module_generator.py
@@ -256,19 +256,23 @@ def create_python_module(module_name,
     # Create the parent directory if it doesn't exist
     os.makedirs(location, exist_ok=True)
 
-    # Create an empty __init__.py file
+    # Generated files are Python source, which the interpreter decodes as
+    # UTF-8 by default (PEP 3120). Write them as UTF-8 explicitly so any
+    # non-ASCII content (e.g. provenance docstrings) round-trips on
+    # interpreters whose locale default is not UTF-8, such as Windows
+    # (cp1252), where ``open(..., "w")`` would otherwise corrupt them.
     init_path = os.path.join(location, "__init__.py")
-    with open(init_path, "w") as file:
+    with open(init_path, "w", encoding="utf-8") as file:
         file.write(initiate_code)
 
     # Create the file with the dependency code
     module_path = os.path.join(location, "dependency.py")
-    with open(module_path, "w") as file:
+    with open(module_path, "w", encoding="utf-8") as file:
         file.write(dependency_code)
 
     # Create the file with the module code
     module_path = os.path.join(location, "num_func.py")
-    with open(module_path, "w") as file:
+    with open(module_path, "w", encoding="utf-8") as file:
         file.write(module_code)
 
     save(auxiliary, os.path.join(location, "param_and_setting.pkl"))

--- a/Solverz/equation/source.py
+++ b/Solverz/equation/source.py
@@ -46,9 +46,15 @@ def stamp_source(model, *, component, package, version, overwrite=False):
 
 
 def format_source(source):
-    """Return a one-line ``' — <package> <version> / <component>'`` suffix
-    for a source dict, or ``''`` when ``source`` is falsy."""
+    """Return a one-line ``' - <package> <version> / <component>'`` suffix
+    for a source dict, or ``''`` when ``source`` is falsy.
+
+    The separator is plain ASCII on purpose: this string is embedded as a
+    docstring inside generated ``.py`` source, and a non-ASCII character
+    (e.g. an em-dash) breaks importing that module on interpreters whose
+    default source encoding is not UTF-8.
+    """
     if not source:
         return ''
-    return (f" — {source.get('package', '?')} "
+    return (f" - {source.get('package', '?')} "
             f"{source.get('version', '?')} / {source.get('component', '?')}")

--- a/docs/src/release_notes.md
+++ b/docs/src/release_notes.md
@@ -2,6 +2,12 @@
 
 # Release Notes
 
+## 0.10.1
+
+### Fixed
+
+- **Generated modules with provenance docstrings failed to import on Windows.** The 0.10.0 provenance docstrings used a Unicode em-dash as the source separator, and the module printer wrote the generated `.py` files with `open(..., "w")`, which uses the OS locale encoding. On Windows (cp1252) the em-dash was written as byte `0x97`, so importing the generated module raised `SyntaxError: 'utf-8' codec can't decode byte 0x97`. This only affected stamped models, so it surfaced once SolMuseum / SolPSDyn began calling `stamp_source`. The printer now writes all generated `.py` files as UTF-8 explicitly, and `format_source` uses a plain ASCII separator, so generated modules import on every platform.
+
 ## 0.10.0
 
 Self-describing generated modules: every `module_printer(...).render()` artifact now carries provenance docstrings, and a new `stamp_source` helper lets reusable components tag the equations they contribute.

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -230,3 +230,36 @@ def test_with_docstring_trailing_quote_or_backslash_compiles():
     for bad in ['ends in quote"', 'ends in backslash\\', 'x"', 'y\\']:
         out = _with_docstring("def f():\n    return 1\n", bad)
         compile(out, '<test>', 'exec')  # raises SyntaxError if malformed
+
+
+def test_generated_module_is_ascii_when_source_is_ascii():
+    """Generated .py stays pure ASCII for ASCII-stamped models, so it
+    imports on interpreters whose default source encoding is not UTF-8.
+
+    Regression: format_source used a Unicode em-dash, which the printer
+    wrote with the OS locale encoding (cp1252 on Windows -> byte 0x97),
+    breaking the UTF-8 import of the generated module for stamped models.
+    """
+    mod = _render(_demo_model_with_source(), jit=False)
+    for fname in ('num_func.py', '__init__.py'):
+        text = _read(mod, fname)
+        bad = sorted({c for c in text if not c.isascii()})
+        assert not bad, f"{fname} has non-ASCII chars: {bad!r}"
+
+
+def test_generated_module_with_nonascii_source_is_utf8_and_imports():
+    """A non-ASCII provenance string is written as UTF-8 and the module
+    still imports (guards the explicit encoding='utf-8' on file write)."""
+    import importlib
+    m = Model()
+    m.x = Var('x', np.ones(1))
+    m.b = Param('b', np.array([1.0]))
+    m.e = Eqn('e', m.x[0] - m.b[0])
+    stamp_source(m, component='café', package='SolMüseum', version='0.3.0')
+    mod = _render(m, jit=False)
+    # The generated source must be valid UTF-8.
+    with open(os.path.join(mod, 'num_func.py'), encoding='utf-8') as f:
+        f.read()
+    # And it must import without a SyntaxError (the original failure mode).
+    sys.path.insert(0, os.path.dirname(mod))
+    importlib.import_module(os.path.basename(mod))


### PR DESCRIPTION
0.10.0 provenance docstrings used a Unicode em-dash, and the module printer wrote generated `.py` with `open(..., "w")` (OS locale encoding). On Windows (cp1252) the em-dash became byte `0x97` → `SyntaxError: 'utf-8' codec can't decode byte 0x97` when importing a **stamped** generated module (surfaced via SolMuseum 0.3.0 / SolPSDyn calling stamp_source; e.g. the cookbook Windows CI).

Fix: write all generated `.py` as UTF-8 explicitly, and use an ASCII separator in `format_source`. Regression tests assert ASCII-stamped output is pure ASCII and that a non-ASCII provenance string round-trips as importable UTF-8. Ships as 0.10.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)