### PR TITLE
fix(rodas): row-equilibrate dense iteration matrices (0.10.1)

### DIFF
--- a/Solverz/solvers/daesolver/rodas/rodas.py
+++ b/Solverz/solvers/daesolver/rodas/rodas.py
@@ -165,7 +165,13 @@ def Rodas(dae: nDAE,
         # the solve well-conditioned. The rhs is scaled by the same factor,
         # so every stage solution is unchanged.
         Miter = M - dt * rparam.gamma * J
-        rscale = (1.0 / np.max(np.abs(Miter), axis=1).toarray()).ravel()
+        # Row max |.|, robust to a sparse, dense-ndarray, or np.matrix
+        # iteration matrix: the dense made_numerical path (sparse=False)
+        # yields a Miter whose row-reduction has no ``.toarray()``.
+        row_max = np.max(np.abs(Miter), axis=1)
+        if hasattr(row_max, 'toarray'):
+            row_max = row_max.toarray()
+        rscale = (1.0 / np.asarray(row_max)).ravel()
         Miter = diags_array(rscale, format='csc') @ Miter
         try:
             lu = lu_decomposition(Miter, backend=linsolver, cache=klu_cache)

--- a/docs/src/release_notes.md
+++ b/docs/src/release_notes.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 
+- **`Rodas` crashed on a dense iteration matrix.** The 0.10.0 Rodas row-equilibration step computed `1 / max|row|` and called `.toarray()` on the row reduction, which only exists for a sparse iteration matrix. A model compiled with `made_numerical(..., sparse=False)` produces a dense `ndarray`, so `Rodas` raised `AttributeError: 'numpy.ndarray' object has no attribute 'toarray'`. The row reduction is now coerced to a flat array for sparse, dense-`ndarray`, and `np.matrix` iteration matrices alike, so the dense `Rodas` path runs and matches the sparse result.
 - **Generated modules with provenance docstrings failed to import on Windows.** The 0.10.0 provenance docstrings used a Unicode em-dash as the source separator, and the module printer wrote the generated `.py` files with `open(..., "w")`, which uses the OS locale encoding. On Windows (cp1252) the em-dash was written as byte `0x97`, so importing the generated module raised `SyntaxError: 'utf-8' codec can't decode byte 0x97`. This only affected stamped models, so it surfaced once SolMuseum / SolPSDyn began calling `stamp_source`. The printer now writes all generated `.py` files as UTF-8 explicitly, and `format_source` uses a plain ASCII separator, so generated modules import on every platform.
 
 ## 0.10.0

--- a/tests/test_rodas_dense.py
+++ b/tests/test_rodas_dense.py
@@ -1,0 +1,33 @@
+"""Regression: Rodas must run with a DENSE iteration matrix.
+
+The row-equilibration step (1/max|row| before the LU) assumed a sparse
+iteration matrix and called ``.toarray()`` on the row reduction. With
+``made_numerical(..., sparse=False)`` the iteration matrix is a dense
+ndarray, so that raised ``AttributeError: 'numpy.ndarray' object has no
+attribute 'toarray'``. This test exercises the dense Rodas path.
+"""
+import numpy as np
+
+from Solverz import Model, Var, Ode, made_numerical, Rodas, Opt
+
+
+def test_rodas_runs_with_dense_jacobian():
+    m = Model()
+    m.x = Var('x', [1.0, 2.0])
+    m.decay = Ode('decay', f=-m.x, diff_var=m.x)
+    sdae, y0 = m.create_instance()
+
+    tspan = np.linspace(0.0, 1.0, 11)
+    opt = Opt(rtol=1e-6, atol=1e-8)
+    # The dense path is the regression: before the fix this raised
+    # AttributeError in the row-equilibration step.
+    sol_den = Rodas(made_numerical(sdae, y0, sparse=False), tspan, y0, opt)
+    sol_sp = Rodas(made_numerical(sdae, y0, sparse=True), tspan, y0, opt)
+
+    # Dense matches sparse (row scaling leaves the solution unchanged)...
+    np.testing.assert_allclose(np.asarray(sol_den.Y['x']),
+                               np.asarray(sol_sp.Y['x']), rtol=1e-8, atol=1e-10)
+    # ...and both match the analytic decay x(t) = x0 * exp(-t).
+    np.testing.assert_allclose(np.asarray(sol_den.Y['x'])[-1],
+                               np.array([1.0, 2.0]) * np.exp(-1.0),
+                               rtol=1e-4, atol=1e-6)


### PR DESCRIPTION
Second fix for 0.10.1. The 0.10.0 Rodas row-equilibration called `.toarray()` on the row reduction, which only exists for sparse iteration matrices; `made_numerical(sparse=False)` yields a dense ndarray so `Rodas` raised `AttributeError: 'numpy.ndarray' object has no attribute 'toarray'` (caught by the cookbook `test_m3b9` dense path). Coerce the row reduction to a flat array for sparse / dense / np.matrix. Adds a dense-Rodas regression test. Folded into the 0.10.1 tag alongside the UTF-8/em-dash printer fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)