### PR TITLE
perf(rodas): decide row-equilibration reduction once per integration

### DIFF
--- a/Solverz/solvers/daesolver/rodas/rodas.py
+++ b/Solverz/solvers/daesolver/rodas/rodas.py
@@ -122,6 +122,10 @@ def Rodas(dae: nDAE,
     klu_cache = KLUCache() if linsolver == 'klu' else None
     done = False
     reject = 0
+    # Whether the row-equilibration reduction densifies (sparse iteration
+    # matrix) or is already dense is fixed for the whole integration, so
+    # decide it once on the first reduction instead of per step.
+    rscale_to_dense = None
     while not done:
         # step size too small
         # pass
@@ -165,11 +169,15 @@ def Rodas(dae: nDAE,
         # the solve well-conditioned. The rhs is scaled by the same factor,
         # so every stage solution is unchanged.
         Miter = M - dt * rparam.gamma * J
-        # Row max |.|, robust to a sparse, dense-ndarray, or np.matrix
-        # iteration matrix: the dense made_numerical path (sparse=False)
-        # yields a Miter whose row-reduction has no ``.toarray()``.
+        # Row max |.| of the (changing) iteration matrix. A sparse Miter
+        # yields a sparse column that must be densified; a dense Miter
+        # (made_numerical(sparse=False)) yields an ndarray with no
+        # ``.toarray()``. The sparse/dense nature is invariant, so judge
+        # it once (first reduction) rather than per step.
         row_max = np.max(np.abs(Miter), axis=1)
-        if hasattr(row_max, 'toarray'):
+        if rscale_to_dense is None:
+            rscale_to_dense = hasattr(row_max, 'toarray')
+        if rscale_to_dense:
             row_max = row_max.toarray()
         rscale = (1.0 / np.asarray(row_max)).ravel()
         Miter = diags_array(rscale, format='csc') @ Miter

--- a/docs/src/release_notes.md
+++ b/docs/src/release_notes.md
@@ -2,6 +2,12 @@
 
 # Release Notes
 
+## 0.10.2
+
+### Changed
+
+- **`Rodas` decides the row-equilibration reduction once per integration.** The row-scale step needs the row maxima of the iteration matrix, which change every step, but whether that reduction yields a sparse column to densify or an already-dense array is fixed for the whole solve. `Rodas` now judges this once on the first reduction instead of type-checking each step, so the dense path never calls `.toarray()` and the sparse path skips the repeated `hasattr` probe.
+
 ## 0.10.1
 
 ### Fixed


### PR DESCRIPTION
The Rodas row-equilibration needs the row maxima of the iteration matrix each step (Miter changes with dt/J), but whether that reduction yields a sparse column to densify vs an already-dense array is invariant for the whole solve. Judge it once on the first reduction instead of per step: the dense `made_numerical(sparse=False)` path never calls `.toarray()`, and the sparse path drops the repeated `hasattr` probe. Solution is unchanged (verified: dense + sparse Rodas regression, test_orbit, cookbook test_m3b9). Ships as 0.10.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)