### PR TITLE
[codex] Move PE and Adams-BDF into Solverz

### DIFF
--- a/Solverz/solvers/daesolver/__init__.py
+++ b/Solverz/solvers/daesolver/__init__.py
@@ -1,5 +1,7 @@
 from Solverz.solvers.daesolver.rodas import Rodas
 from Solverz.solvers.daesolver.radau import Radau
 from Solverz.solvers.daesolver.ode15s import ode15s
+from Solverz.solvers.daesolver.pe import PE
+from Solverz.solvers.daesolver.adams_bdf import AdamsBDF
 from Solverz.solvers.daesolver.beuler import backward_euler
 from Solverz.solvers.daesolver.trapezoidal import implicit_trapezoid

--- a/Solverz/solvers/daesolver/adams_bdf/__init__.py
+++ b/Solverz/solvers/daesolver/adams_bdf/__init__.py
@@ -1,0 +1,1 @@
+from Solverz.solvers.daesolver.adams_bdf.adams_bdf import AdamsBDF

--- a/Solverz/solvers/daesolver/adams_bdf/adams_bdf.py
+++ b/Solverz/solvers/daesolver/adams_bdf/adams_bdf.py
@@ -1,0 +1,493 @@
+"""
+Mixed Adams-BDF variable-step variable-order solver, Nordsieck form
+(Astic, Bihain, Jerosolimski, IEEE TPWRS 9(2):929-935, 1994).
+
+Paper-faithful implementation: it carries the Nordsieck vector and realizes
+the paper's defining "mixed" treatment, in which the Adams method governs the
+differential state variables and the BDF method governs the algebraic state
+variables. The two enter through the Nordsieck l-vector used in the corrector
+update and, critically, in the local-error estimate: the differential-variable
+error uses the Adams l-coefficient and the algebraic-variable error uses the
+BDF l-coefficient, both fed into the error norm. This restores the
+algebraic-variable error control that the earlier direct-history
+implementation omitted.
+
+Nordsieck convention z_j = h^j y^{(j)} / j!, so for order q the array is
+
+    Z = [ y , h y' , (h^2/2) y'' ]   (rows 0..q used).
+
+Predictor: Z_pred = P Z, P the Pascal (binomial) upper-triangular matrix.
+Step change by alpha = h_new/h_old: rescale Z_j <- alpha^j Z_j. Corrector,
+by Newton:
+
+    differential equation rows r (paired variable column c via M[r,c]):
+        h F_r(y_{n+1}) = M[r,c]( Z_pred[1,c] + l1 (y_{n+1,c} - Z_pred[0,c]) )
+    algebraic equation rows r:
+        F_r(y_{n+1}) = 0                                   (paper eq. 3.b)
+
+l1 is the Adams leading coefficient (1 at order 1, 2 at order 2 = trapezoidal).
+After convergence with correction e = y_{n+1} - Z_pred[0], the Nordsieck array
+is updated component-wise with the Adams l-vector on differential columns and
+the BDF l-vector on algebraic columns.
+
+l-vectors, convention z_j = h^j y^{(j)}/j! (l0 = 1, l1 = 1/beta0):
+    order 1 (Adams1 = BDF1 = implicit Euler):  l = [1, 1]
+    order 2 Adams (trapezoidal, differential): l = [1, 2,   1  ]
+    order 2 BDF  (algebraic):                  l = [1, 3/2, 1/2]
+
+Local error at order q: E_i = l_q^{method(i)} e_i, Adams l_q on differential,
+BDF l_q on algebraic, then a max norm (the paper's anti-hyper-stability norm).
+At order 2 l_2^{BDF}=1/2 < l_2^{Adams}=1, so the algebraic-variable error is
+less restrictive, exactly the paper's reason for BDF on algebraic variables.
+
+Retained paper features: order capped at 2; Very-Dishonest Newton; step-and-
+order hold for >= q+1 steps; 10% step-increase acceptance hysteresis; self-
+start at order 1; re-init to order 1 with the minimum step on any event;
+optional ADAMSBDF_TRACE per-step trace.
+"""
+
+import os
+import warnings
+
+import numpy as np
+from numpy import linalg
+from scipy.sparse import diags_array, csc_matrix, issparse
+from tqdm import tqdm
+
+from Solverz.solvers.daesolver.utilities import *
+
+_TRACE = []
+_TRACE_ON = os.environ.get('ADAMSBDF_TRACE', '0') == '1'
+
+# Nordsieck l-vectors, convention z_j = h^j y^{(j)}/j!, l0 = 1, l1 = 1/beta0.
+_L_EULER = np.array([1.0, 1.0, 0.0])
+_L_ADAMS2 = np.array([1.0, 2.0, 1.0])
+_L_BDF2 = np.array([1.0, 1.5, 0.5])
+
+
+@dae_io_parser
+def AdamsBDF(dae: nDAE, tspan, y0, opt: Opt = None):
+    """Nordsieck-form mixed Adams-BDF solver. See module docstring."""
+    if opt is None:
+        opt = Opt()
+    stats = Stats(scheme='AdamsBDF-Nordsieck')
+    if _TRACE_ON:
+        _TRACE.clear()
+
+    vsize = y0.shape[0]
+    tspan = np.asarray(tspan, dtype=float)
+    t0, tend = float(tspan[0]), float(tspan[-1])
+    if t0 > tend:
+        raise ValueError(f't0 {t0} > tend {tend}')
+    if opt.hmax is None:
+        opt.hmax = abs(tend - t0)
+
+    M = (dae.M if issparse(dae.M) else csc_matrix(dae.M)).tocsc()
+    Mcoo = M.tocoo()
+    diff_rows = Mcoo.row.astype(int)
+    diff_cols = Mcoo.col.astype(int)
+    diff_vals = np.where(np.abs(Mcoo.data) < 1e-30, 1.0, Mcoo.data.astype(float))
+    DiffVar = np.zeros(vsize, dtype=bool)
+    DiffVar[diff_cols] = True
+    AlgVar = ~DiffVar
+    DiffEqn = np.zeros(vsize, dtype=bool)
+    DiffEqn[diff_rows] = True
+    AlgEqn = ~DiffEqn
+    n_diff = int(DiffVar.sum())
+    has_alg = bool(AlgVar.any())
+    if n_diff == 0:
+        warnings.warn('AdamsBDFns: no differential rows; degenerates to Newton.')
+
+    dense_output = len(tspan) > 2
+    n_buf = len(tspan) if dense_output else 10001
+    if dense_output:
+        inext = 1
+        tnext = float(tspan[inext])
+    T = np.zeros(n_buf)
+    Y = np.zeros((n_buf, vsize))
+    stats.order_variation = np.zeros(n_buf)
+
+    y0 = DaeIc(dae, y0, t0, opt.rtol)
+    yp0 = getyp0(dae, y0, t0)
+    T[0], Y[0] = t0, y0
+    nt = 0
+
+    threshold = opt.atol / opt.rtol
+    uround = np.spacing(1.0)
+    hmin = 16.0 * np.spacing(t0)
+
+    if opt.hinit is None:
+        wt0 = np.maximum(np.abs(y0), threshold)
+        rh = 1.25 * linalg.norm(yp0 / wt0, np.inf) / opt.rtol ** 0.5
+        absh = min(opt.hmax, tend - t0)
+        if absh * rh > 1.0:
+            absh = 1.0 / rh
+        absh = max(absh, hmin)
+    else:
+        absh = min(opt.hmax, max(hmin, opt.hinit))
+
+    Z = np.zeros((3, vsize))
+    Z[0] = y0
+    Z[1] = absh * yp0
+
+    t = t0
+    order = 1
+    stats.order_variation[0] = order
+    h = absh
+    n_at_curr = 0
+
+    J_cached = _eval_J(dae, t, y0, vsize, getattr(opt, 'numJac', False))
+    stats.nJeval += 1
+    Jcurrent = True
+    lu = rscale = None
+    cached_h = cached_order = None
+
+    maxit = max(getattr(opt, 'ndfmaxit', 4) or 4, 8)
+    pbar = tqdm(total=tend - t0) if opt.pbar else None
+
+    events_fn = getattr(opt, 'event', None)
+    have_events = events_fn is not None
+    if have_events:
+        prev_ev, _, direction = events_fn(t0, y0)
+        prev_ev = np.asarray(prev_ev, dtype=float)
+        direction = np.asarray(direction, dtype=float)
+        te = np.zeros(1001)
+        ye = np.zeros((1001, vsize))
+        ie = np.zeros(1001, dtype=int)
+        nevent = -1
+        force_reinit = False
+
+    done = stopped_by_event = False
+    while not done:
+        hmin = 16.0 * np.spacing(t)
+        absh = max(hmin, min(opt.hmax, absh))
+
+        # Rescale the Nordsieck array if the step changed.
+        if abs(absh - h) > 1e-13 * max(h, 1.0):
+            alpha = absh / h
+            Z[1] *= alpha
+            Z[2] *= alpha * alpha
+            h = absh
+
+        if 1.1 * absh >= abs(tend - t):
+            new_h = tend - t
+            if new_h > 0 and abs(new_h - h) > 1e-13 * max(h, 1.0):
+                alpha = new_h / h
+                Z[1] *= alpha
+                Z[2] *= alpha * alpha
+            h = absh = new_h
+            done = True
+
+        K = order
+        if have_events and force_reinit:
+            K = order = 1
+            absh = max(hmin, min(absh, 1e-3 * max(opt.hmax, 1e-3)))
+            h = absh
+            Z[1] = h * _yp(dae.F(t, Z[0], dae.p), diff_rows, diff_cols, diff_vals)
+            stats.nfeval += 1
+            Z[2] = 0.0
+            n_at_curr = 0
+            force_reinit = False
+            cached_h = None
+            done = (1.1 * absh >= abs(tend - t))
+
+        l1 = _L_ADAMS2[1] if K == 2 else _L_EULER[1]
+
+        if (cached_h is None or abs(cached_h - h) > 1e-12 * max(h, 1.0)
+                or cached_order != K):
+            lu, rscale = _build_lu(M, h, J_cached, l1, DiffEqn)
+            stats.ndecomp += 1
+            cached_h, cached_order = h, K
+
+        y_n = Z[0].copy()
+        yp_n = Z[1] / h if h > 0 else np.zeros(vsize)
+        Zp = _predict(Z, K)
+        y_pred = Zp[0].copy()
+        z1_pred = Zp[1]
+
+        # Newton.
+        y_new = y_pred.copy()
+        success = False
+        oldnrm = None
+        for _ in range(maxit):
+            F_new = dae.F(t + h, y_new, dae.p)
+            stats.nfeval += 1
+            e = y_new - y_pred
+            G = np.empty(vsize)
+            G[DiffEqn] = (h * F_new[DiffEqn] - (M @ (z1_pred + l1 * e))[DiffEqn])
+            G[AlgEqn] = F_new[AlgEqn]
+            del_y = lu.solve(rscale * (-G))
+            stats.nsolve += 1
+            y_new += del_y
+            wt = np.maximum(np.maximum(np.abs(y_n), np.abs(y_new)), threshold)
+            newnrm = linalg.norm(del_y / wt, np.inf)
+            if newnrm < 1e-10:
+                success = True
+                break
+            if oldnrm is not None:
+                rate = newnrm / max(oldnrm, 1e-30)
+                if rate >= 0.9:
+                    break
+                if newnrm * rate / max(1.0 - rate, 1e-30) < 0.1 * opt.rtol:
+                    success = True
+                    break
+            oldnrm = newnrm
+
+        if not success:
+            stats.nreject += 1
+            if not Jcurrent:
+                J_cached = _eval_J(dae, t, y_n, vsize, getattr(opt, 'numJac', False))
+                stats.nJeval += 1
+                Jcurrent = True
+                cached_h = None
+                done = False
+                continue
+            absh = max(0.3 * absh, hmin)
+            if absh <= hmin:
+                print(f'AdamsBDFns: step too small at t={t}.')
+                stats.ret = 'failed'
+                break
+            cached_h = None
+            n_at_curr = 0
+            done = False
+            continue
+
+        e = y_new - y_pred
+        wt = np.maximum(np.maximum(np.abs(y_n), np.abs(y_new)), threshold)
+        lq_A = (_L_ADAMS2 if K == 2 else _L_EULER)[K]
+        lq_B = (_L_BDF2 if K == 2 else _L_EULER)[K]
+        err_vec = np.empty(vsize)
+        err_vec[DiffVar] = lq_A * e[DiffVar]
+        err_vec[AlgVar] = lq_B * e[AlgVar]
+        err = linalg.norm(err_vec / wt, np.inf)
+
+        if _TRACE_ON:
+            _TRACE.append((float(t), float(h), int(K), float(err),
+                           bool(err <= opt.rtol)))
+
+        if err > opt.rtol:
+            stats.nreject += 1
+            if K == 2:
+                order = 1
+                n_at_curr = 0
+            absh = max(0.1 * absh,
+                       0.8 * absh * (opt.rtol / max(err, 1e-30)) ** (1.0 / (K + 1)))
+            if absh <= hmin:
+                print(f'AdamsBDFns: step too small after rejection at t={t}.')
+                stats.ret = 'failed'
+                break
+            cached_h = None
+            Jcurrent = False
+            n_at_curr = 0
+            done = False
+            continue
+
+        # Accept: Nordsieck update with mixed l-vectors.
+        lA = _L_ADAMS2 if K == 2 else _L_EULER
+        lB = _L_BDF2 if K == 2 else _L_EULER
+        z1_old = Z[1].copy()
+        Znew = Zp.copy()
+        Znew[0] = y_new
+        Znew[1, DiffVar] = Zp[1, DiffVar] + lA[1] * e[DiffVar]
+        Znew[1, AlgVar] = Zp[1, AlgVar] + lB[1] * e[AlgVar]
+        if K == 2:
+            Znew[2, DiffVar] = Zp[2, DiffVar] + lA[2] * e[DiffVar]
+            Znew[2, AlgVar] = Zp[2, AlgVar] + lB[2] * e[AlgVar]
+        else:
+            Znew[2] = 0.5 * (Znew[1] - z1_old)
+        Z = Znew
+
+        stats.nstep += 1
+        t_new = t + h
+        n_at_curr += 1
+        yp_new = _yp(dae.F(t_new, y_new, dae.p), diff_rows, diff_cols, diff_vals)
+        stats.nfeval += 1
+
+        if dense_output:
+            while inext < len(tspan) and t_new >= tnext > t:
+                s = (tnext - t) / h
+                nt += 1
+                if nt >= T.shape[0]:
+                    T = np.concatenate([T, np.zeros(1000)])
+                    Y = np.concatenate([Y, np.zeros((1000, vsize))])
+                    stats.order_variation = np.concatenate(
+                        [stats.order_variation, np.zeros(1000)])
+                T[nt] = tnext
+                Y[nt] = _hermite(s, y_n, y_new, yp_n, yp_new, h)
+                stats.order_variation[nt] = K
+                if pbar:
+                    pbar.update(T[nt] - T[nt - 1])
+                inext += 1
+                tnext = float(tspan[inext]) if inext < len(tspan) else tend + h
+        else:
+            nt += 1
+            if nt >= T.shape[0]:
+                T = np.concatenate([T, np.zeros(1000)])
+                Y = np.concatenate([Y, np.zeros((1000, vsize))])
+                stats.order_variation = np.concatenate(
+                    [stats.order_variation, np.zeros(1000)])
+            T[nt], Y[nt] = t_new, y_new
+            stats.order_variation[nt] = K
+            if pbar:
+                pbar.update(T[nt] - T[nt - 1])
+
+        if have_events:
+            new_ev, _, new_dir, hits = _locate_events(
+                events_fn, t, t_new, y_n, y_new, yp_n, yp_new, h,
+                prev_ev, direction, uround, opt.event_duration)
+            if hits:
+                for (te_i, ye_i, ie_i, term_i) in hits:
+                    nevent += 1
+                    if nevent == te.size:
+                        te = np.concatenate([te, np.zeros(1000)])
+                        ye = np.concatenate([ye, np.zeros((1000, vsize))])
+                        ie = np.concatenate([ie, np.zeros(1000, dtype=int)])
+                    te[nevent], ye[nevent], ie[nevent] = te_i, ye_i, ie_i
+                force_reinit = True
+                last_te, last_ye, _, last_term = hits[-1]
+                if last_term:
+                    t_new, y_new = last_te, last_ye.copy()
+                    done = stopped_by_event = True
+                    if dense_output:
+                        # Drop grid points reported beyond the event, then
+                        # APPEND the exact event point so T[-1] is the true
+                        # crossing time (not the last grid point before it).
+                        while nt > 0 and T[nt] > t_new:
+                            nt -= 1
+                        nt += 1
+                        if nt >= T.shape[0]:
+                            T = np.concatenate([T, np.zeros(1000)])
+                            Y = np.concatenate([Y, np.zeros((1000, vsize))])
+                            stats.order_variation = np.concatenate(
+                                [stats.order_variation, np.zeros(1000)])
+                        T[nt], Y[nt] = t_new, y_new
+                        stats.order_variation[nt] = K
+                    else:
+                        T[nt], Y[nt] = t_new, y_new
+            prev_ev, direction = new_ev, new_dir
+
+        # Order + step selection (order <= 2, 1-vs-2 by projected step).
+        z2 = Z[2]
+        err_o1 = 0.0
+        if n_diff:
+            err_o1 = max(err_o1, linalg.norm(z2[DiffVar] / wt[DiffVar], np.inf))
+        if has_alg:
+            err_o1 = max(err_o1, linalg.norm(z2[AlgVar] / wt[AlgVar], np.inf))
+        h_o1 = absh * max(0.1, 0.9 * (opt.rtol / max(err_o1, 1e-30)) ** 0.5)
+        if K == 2:
+            h_o2 = absh * max(0.1, 0.9 * (opt.rtol / max(err, 1e-30)) ** (1.0 / 3.0))
+        else:
+            h_o2 = 1.5 * h_o1  # bias toward order 2 after self-start
+        new_order = 2 if h_o2 >= h_o1 else 1
+        absh_cand = max(0.5 * absh, min(2.0 * absh, max(h_o1, h_o2)))
+
+        if n_at_curr >= K + 1:
+            order_changed = new_order != order
+            h_changed = abs(absh_cand - absh) >= 0.1 * absh
+            if order_changed:
+                if new_order == 1:
+                    Z[2] = 0.5 * (Z[1] - z1_old)
+                order = new_order
+                n_at_curr = 0
+            if h_changed:
+                absh = absh_cand
+                if not order_changed:
+                    n_at_curr = 0
+
+        t = t_new
+        Jcurrent = False
+        if stopped_by_event:
+            break
+
+    T, Y = T[:nt + 1], Y[:nt + 1]
+    stats.order_variation = stats.order_variation[:nt + 1]
+    if pbar:
+        pbar.close()
+    if stats.ret != 'failed':
+        stats.succeed = True
+    if have_events and nevent >= 0:
+        return daesol(T, Y, te=te[:nevent + 1], ye=ye[:nevent + 1],
+                      ie=ie[:nevent + 1], stats=stats)
+    return daesol(T, Y, stats=stats)
+
+
+def _predict(Z, K):
+    Zp = Z.copy()
+    if K == 1:
+        Zp[0] = Z[0] + Z[1]
+        Zp[1] = Z[1]
+    else:
+        Zp[0] = Z[0] + Z[1] + Z[2]
+        Zp[1] = Z[1] + 2.0 * Z[2]
+        Zp[2] = Z[2]
+    return Zp
+
+
+def _eval_J(dae, t, y, vsize, eval_numjac=False):
+    if eval_numjac:
+        from Solverz.num_api.numjac import numjac
+        _, dFdyt, _ = numjac(lambda t_, y_: dae.F(t_, y_, dae.p), t, y,
+                             dae.F(t, y, dae.p), 1e-5 * np.ones_like(y), 0, 0, 0, 0)
+        return dFdyt[:, 0:vsize]
+    return dae.J(t, y, dae.p)
+
+
+def _build_lu(M, h, J, l1, DiffEqn):
+    M_csc = M if issparse(M) else csc_matrix(M)
+    J_csc = J if issparse(J) else csc_matrix(J)
+    row_scale_J = np.where(DiffEqn, h, 1.0)
+    W = diags_array(row_scale_J, format='csc') @ J_csc - l1 * M_csc
+    row_max = np.max(np.abs(W), axis=1).toarray().ravel()
+    rscale = 1.0 / np.maximum(row_max, 1e-30)
+    W = diags_array(rscale, format='csc') @ W
+    return lu_decomposition(W), rscale
+
+
+def _yp(F_val, diff_rows, diff_cols, diff_vals):
+    yp = np.zeros_like(F_val)
+    yp[diff_cols] = F_val[diff_rows] / diff_vals
+    return yp
+
+
+def _hermite(s, y_n, y_new, yp_n, yp_new, h):
+    h0 = (1.0 - s) ** 2 * (1.0 + 2.0 * s)
+    h1 = s * s * (3.0 - 2.0 * s)
+    h2 = s * (1.0 - s) ** 2
+    h3 = -(s * s) * (1.0 - s)
+    return h0 * y_n + h1 * y_new + h * h2 * yp_n + h * h3 * yp_new
+
+
+def _locate_events(events_fn, t_n, t_new, y_n, y_new, yp_n, yp_new, h,
+                   prev_vals, direction, uround, event_dur):
+    nv, new_isterm, new_dir = events_fn(t_new, y_new)
+    new_vals = np.asarray(nv, dtype=float)
+    new_isterm = np.asarray(new_isterm)
+    new_dir = np.asarray(new_dir, dtype=float)
+    hits = []
+    for i in np.where(prev_vals * new_vals < 0)[0]:
+        v0, v1 = prev_vals[i], new_vals[i]
+        if direction[i] < 0 and v0 <= v1:
+            continue
+        if direction[i] > 0 and v0 >= v1:
+            continue
+        tL, tR = t_n, t_new
+        t_e = t_n - v0 * h / (v1 - v0) if abs(v1 - v0) > uround else t_new
+        tol = max(128.0 * uround, event_dur)
+        for _ in range(60):
+            s = (t_e - t_n) / h
+            y_e = _hermite(s, y_n, y_new, yp_n, yp_new, h)
+            v_now = np.asarray(events_fn(t_e, y_e)[0], dtype=float)[i]
+            if v1 * v_now < 0:
+                tL, v0, t_e = t_e, v_now, 0.5 * (t_e + tR)
+            elif v0 * v_now < 0:
+                tR, v1, t_e = t_e, v_now, 0.5 * (tL + t_e)
+            else:
+                break
+            if (tR - tL) < tol:
+                break
+        if t_e - t_n < event_dur:
+            continue
+        y_e = _hermite((t_e - t_n) / h, y_n, y_new, yp_n, yp_new, h)
+        hits.append((t_e, y_e, int(i), bool(new_isterm[i])))
+    hits.sort(key=lambda r: r[0])
+    return new_vals, new_isterm, new_dir, hits

--- a/Solverz/solvers/daesolver/pe/__init__.py
+++ b/Solverz/solvers/daesolver/pe/__init__.py
@@ -1,0 +1,1 @@
+from Solverz.solvers.daesolver.pe.pe import PE

--- a/Solverz/solvers/daesolver/pe/pe.py
+++ b/Solverz/solvers/daesolver/pe/pe.py
@@ -1,0 +1,433 @@
+"""
+Partitioned-explicit (PE) DAE solver, with a modified-Euler variant.
+
+This implements the partitioned-explicit integration scheme of Sauer, Pai
+and Chow, *Power System Dynamics and Stability* (2nd ed., Wiley/IEEE Press,
+2018), Chapter 7, Section 7.7.5. The differential-algebraic model is written
+in the Solverz semi-explicit form
+
+    M y' = F(t, y),      M singular (diagonal),
+
+so the rows where ``M`` has a nonzero diagonal are the *differential*
+equations and their paired columns are the *differential* (state) variables
+``x``; the rows where ``M`` is zero are the *algebraic* (network/interface)
+equations and their paired columns are the *algebraic* variables ``z``. The
+PE method advances the two blocks in an alternating, partitioned fashion:
+
+  1. Hold the algebraic variables fixed and step the differential states
+     *explicitly* (no implicit coupling of x_{n+1} to its own RHS).
+  2. Hold the freshly stepped states fixed and *solve the algebraic block*
+     0 = F_a(t_{n+1}, x_{n+1}, z_{n+1}) for z_{n+1} by Newton iteration
+     (the "network/interface solution").
+
+This is the book's PE loop (7.156)-(7.158): integrate ``x' = f(x, I_dq, V)``
+to obtain ``x(n+1)``, then re-solve the algebraic equations for the new
+``I_dq(n+1), V(n+1)``.
+
+Two explicit integrators are provided through ``Opt(scheme=...)``:
+
+  * ``scheme='euler'``           : forward (explicit) Euler.  The basic PE.
+  * ``scheme='modified_euler'``  : Heun's improved/modified-Euler predictor
+    (default).  This is the "improved-Euler version" of the PE method:
+
+        x_p      = x_n + h f(t_n, x_n, z_n)          (predictor)
+        z_p      : solve  F_a(t_{n+1}, x_p, z_p) = 0 (network solve)
+        x_{n+1}  = x_n + (h/2)[f(t_n, x_n, z_n) + f(t_{n+1}, x_p, z_p)]
+        z_{n+1}  : solve  F_a(t_{n+1}, x_{n+1}, z_{n+1}) = 0
+
+The PE method is a *fixed-step* method: the step is ``opt.step_size`` (it has
+no embedded error estimate, hence no per-step tolerance). Its maximum stable
+step is set by the fastest mode of the explicit differential block; on a
+method-of-lines gas network plus electromechanical machine dynamics this is a
+CFL-type limit, so a very small fixed step is required across the whole
+horizon. That is precisely the property this baseline is meant to expose.
+
+Robustness for very long horizons (the cascade horizon is tens of thousands
+of seconds, so a small fixed step yields 1e6-1e8 internal steps):
+
+  * Memory is bounded. The solution is reported on the requested ``tspan``
+    nodes when ``len(tspan) > 2`` (dense-output style), or on a uniform grid
+    of ``opt`` -capped size when ``len(tspan) == 2``. The internal fixed-step
+    march is never stored in full. Within-step reporting uses linear
+    interpolation, consistent with the method's first/second order.
+  * Divergence is detected. A non-finite state, or a failure of the
+    algebraic Newton to converge, terminates the run with ``stats.ret =
+    'failed'`` and returns the trajectory accumulated so far rather than
+    raising.
+  * The algebraic Newton uses a held-Jacobian factorization of the
+    algebraic Jacobian block J_aa = (dF_a/dz), refreshed only when the inner
+    iteration stalls or fails, following Section 7.8.1 of the reference. This
+    keeps the per-step cost dominated by F evaluations and back-substitutions
+    rather than by a fresh sparse LU at every micro-step.
+
+Event handling mirrors the other Solverz solvers: an optional ``opt.event``
+callable ``g(t, y) -> (value, isterminal, direction)`` is checked after every
+accepted step; a sign change is located within the step by a secant +
+bisection root finder on a *linear* interpolant of the step, and a terminal
+event stops the integration and is reported through ``daesol.te/ye/ie``.
+"""
+
+import warnings
+
+import numpy as np
+from numpy import linalg
+from scipy.sparse import csc_matrix, issparse
+from tqdm import tqdm
+
+from Solverz.solvers.daesolver.utilities import *
+
+
+# Default number of uniform report nodes when tspan has only [t0, tend]
+# (a 2-point, event-terminated phase). Bounds memory regardless of how many
+# internal fixed steps the PE march takes.
+_DEFAULT_NREPORT = 10001
+# Inner algebraic-Newton controls.
+_ALG_MAXIT = 30          # max Newton iterations for the algebraic block
+_ALG_REFRESH_ITERS = 4   # refresh the held J_aa if the inner solve needs more
+
+
+@dae_io_parser
+def PE(dae: nDAE,
+       tspan,
+       y0,
+       opt: Opt = None):
+    """Partitioned-explicit DAE solver. See the module docstring.
+
+    Parameters
+    ----------
+    dae : nDAE
+        Semi-explicit DAE ``M y' = F(t, y)`` with singular diagonal ``M``.
+    tspan : array-like
+        ``[t0, tend]`` for raw reporting on a capped uniform grid, or a
+        length >= 3 array of report instants for dense-output reporting.
+    y0 : ndarray
+        Initial state (made consistent with the algebraic constraints by
+        ``DaeIc`` before the march starts).
+    opt : Opt
+        ``step_size`` sets the fixed step. ``scheme`` selects ``'euler'`` or
+        ``'modified_euler'`` (default). ``event``, ``pbar`` as usual.
+    """
+    if opt is None:
+        opt = Opt()
+    scheme = (getattr(opt, 'scheme', None) or 'modified_euler').lower()
+    if scheme in ('me', 'meuler', 'heun', 'improved_euler', 'modified-euler'):
+        scheme = 'modified_euler'
+    if scheme in ('fe', 'feuler', 'forward_euler'):
+        scheme = 'euler'
+    if scheme not in ('euler', 'modified_euler'):
+        # Any unrelated scheme name (e.g. a rodas/NDF default) maps to the
+        # improved-Euler PE so a shared Opt across solvers still runs.
+        scheme = 'modified_euler'
+    stats = Stats(scheme=f'PE/{scheme}')
+
+    vsize = y0.shape[0]
+    tspan = np.asarray(tspan, dtype=float)
+    t0 = float(tspan[0])
+    tend = float(tspan[-1])
+    if t0 > tend:
+        raise ValueError(f't0 {t0} > tend {tend}')
+
+    h = float(getattr(opt, 'step_size', None) or 1e-3)
+    if h <= 0:
+        raise ValueError(f'PE needs a positive step_size, got {h}')
+
+    # --- differential / algebraic partition from the mass matrix ---------
+    # The Solverz mass matrix M is in general NOT diagonal: each
+    # differential equation is one off-diagonal entry M[r, c] coupling
+    # equation row r to its state-variable column c, i.e. the differential
+    # equation reads  M[r, c] * d(y[c])/dt = F[r].  The differential
+    # equation ROWS (set of r) and the differential variable COLUMNS (set
+    # of c) are therefore distinct index sets, and the algebraic block must
+    # be sliced with the distinct masks J[alg_eqn_rows, alg_var_cols] -- the
+    # index-matched J[alg_var, alg_var] block is singular for this model.
+    M = dae.M if issparse(dae.M) else csc_matrix(dae.M)
+    Mcoo = M.tocoo()
+    diff_rows = Mcoo.row.astype(int)   # differential equation indices (r)
+    diff_cols = Mcoo.col.astype(int)   # paired state-variable indices (c)
+    diff_vals = Mcoo.data.astype(float)  # mass coefficients M[r, c]
+    if np.any(np.abs(diff_vals) < 1e-30):
+        diff_vals = np.where(np.abs(diff_vals) < 1e-30, 1.0, diff_vals)
+    n_diff = diff_cols.size
+
+    DiffVarMask = np.zeros(vsize, dtype=bool)
+    DiffVarMask[diff_cols] = True
+    AlgVarMask = ~DiffVarMask
+    DiffEqnMask = np.zeros(vsize, dtype=bool)
+    DiffEqnMask[diff_rows] = True
+    AlgEqnMask = ~DiffEqnMask
+    alg_eqn_rows = np.where(AlgEqnMask)[0]
+    alg_var_cols = np.where(AlgVarMask)[0]
+    n_alg = alg_var_cols.size
+    if n_diff == 0:
+        warnings.warn('PE: no differential rows; the model is purely algebraic.')
+
+    def f_diff(F_full):
+        """Explicit differential RHS dy[c]/dt = F[r] / M[r, c], returned in
+        the order of ``diff_cols`` (the differential state variables)."""
+        return F_full[diff_rows] / diff_vals
+
+    # --- consistent initial state ---------------------------------------
+    y0 = DaeIc(dae, y0, t0, opt.rtol)
+
+    # --- output buffers --------------------------------------------------
+    dense_output = len(tspan) > 2
+    if dense_output:
+        report_t = tspan.copy()
+    else:
+        report_t = np.linspace(t0, tend, _DEFAULT_NREPORT)
+    n_report = report_t.size
+    T = np.zeros(n_report)
+    Y = np.zeros((n_report, vsize))
+    T[0] = t0
+    Y[0] = y0
+    nt = 0
+    inext = 1
+    tnext = report_t[inext] if n_report > 1 else tend + h
+
+    threshold = opt.atol / opt.rtol
+    uround = np.spacing(1.0)
+
+    # --- event support ---------------------------------------------------
+    events_fn = getattr(opt, 'event', None)
+    have_events = events_fn is not None
+    if have_events:
+        prev_vals, isterminal, direction = events_fn(t0, y0)
+        prev_vals = np.asarray(prev_vals, dtype=float)
+        direction = np.asarray(direction, dtype=float)
+        te = np.zeros(1001)
+        ye = np.zeros((1001, vsize))
+        ie = np.zeros(1001, dtype=int)
+        nevent = -1
+
+    # --- held algebraic Jacobian factorization (VDHN) --------------------
+    alg_state = {'lu': None}
+
+    def refresh_alg_lu(t, y):
+        J = dae.J(t, y, dae.p)
+        stats.nJeval += 1
+        J = (J if issparse(J) else csc_matrix(J)).tocsc()
+        Jaa = J[alg_eqn_rows][:, alg_var_cols].tocsc()
+        alg_state['lu'] = lu_decomposition(Jaa)
+        stats.ndecomp += 1
+
+    def solve_alg(t, y_with_diff_fixed):
+        """Solve F_a(t, y) = 0 over the algebraic variables y[alg_var_cols]
+        by held-Jacobian Newton, with the differential variables held at the
+        values already written into ``y_with_diff_fixed``.
+
+        Returns (y, F_full, ok). On non-convergence ok=False (caller aborts).
+        The full residual at the converged point is returned so the caller
+        can extract the differential RHS without a re-evaluation.
+        """
+        y = y_with_diff_fixed  # modified in place on the algebraic entries
+        if n_alg == 0:
+            F_full = dae.F(t, y, dae.p)
+            stats.nfeval += 1
+            return y, F_full, True
+        if alg_state['lu'] is None:
+            refresh_alg_lu(t, y)
+        refreshed_here = False
+        F_full = None
+        for it in range(1, _ALG_MAXIT + 1):
+            F_full = dae.F(t, y, dae.p)
+            stats.nfeval += 1
+            res = F_full[alg_eqn_rows]
+            wt = np.maximum(np.abs(y[alg_var_cols]), threshold)
+            del_z = alg_state['lu'].solve(-res)
+            stats.nsolve += 1
+            y[alg_var_cols] += del_z
+            relnorm = linalg.norm(del_z / wt, np.inf)
+            if not np.all(np.isfinite(y[alg_var_cols])):
+                return y, F_full, False
+            if relnorm < opt.ite_tol:
+                # Refresh the held factorization if convergence was slow, so
+                # the next step starts from a current Jaa (VDHN heuristic).
+                if it > _ALG_REFRESH_ITERS:
+                    refresh_alg_lu(t, y)
+                return y, F_full, True
+            # Stalled: refresh the Jacobian once and keep iterating.
+            if it == _ALG_REFRESH_ITERS and not refreshed_here:
+                refresh_alg_lu(t, y)
+                refreshed_here = True
+        return y, F_full, False
+
+    # --- initial split + first RHS --------------------------------------
+    refresh_alg_lu(t0, y0)
+    F_n = dae.F(t0, y0, dae.p)
+    stats.nfeval += 1
+    f_n = f_diff(F_n)
+
+    t = t0
+    y_n = y0.copy()
+    pbar = tqdm(total=tend - t0) if opt.pbar else None
+    done = False
+    stopped_by_event = False
+
+    while not done:
+        # Final partial step lands exactly on tend.
+        h_step = h
+        if t + h_step >= tend - 1e-12 * max(abs(tend), 1.0):
+            h_step = tend - t
+            done = True
+        if h_step <= 0:
+            break
+
+        t_new = t + h_step
+
+        # ---- explicit differential update ------------------------------
+        # Start the new state from the previous one: algebraic entries seed
+        # the network Newton, differential entries are overwritten below.
+        if scheme == 'euler':
+            y_new = y_n.copy()
+            y_new[diff_cols] = y_n[diff_cols] + h_step * f_n
+            y_new, F_new, ok = solve_alg(t_new, y_new)
+            if not ok:
+                _fail(stats, t_new, 'algebraic Newton diverged (euler step)')
+                break
+        else:  # modified_euler (Heun)
+            y_p = y_n.copy()
+            y_p[diff_cols] = y_n[diff_cols] + h_step * f_n
+            y_p, F_p, ok = solve_alg(t_new, y_p)
+            if not ok:
+                _fail(stats, t_new, 'algebraic Newton diverged (predictor)')
+                break
+            f_p = f_diff(F_p)
+            y_new = y_p.copy()
+            y_new[diff_cols] = y_n[diff_cols] + 0.5 * h_step * (f_n + f_p)
+            y_new, F_new, ok = solve_alg(t_new, y_new)
+            if not ok:
+                _fail(stats, t_new, 'algebraic Newton diverged (corrector)')
+                break
+
+        if not np.all(np.isfinite(y_new)):
+            _fail(stats, t_new, 'non-finite state')
+            break
+
+        stats.nstep += 1
+
+        # ---- reporting on the requested grid (linear within step) ------
+        while inext < n_report and t < tnext <= t_new + 1e-12:
+            s = (tnext - t) / h_step if h_step > 0 else 1.0
+            y_at = y_n + s * (y_new - y_n)
+            nt += 1
+            T[nt] = tnext
+            Y[nt] = y_at
+            inext += 1
+            tnext = report_t[inext] if inext < n_report else tend + h
+        if pbar:
+            pbar.update(h_step)
+
+        # ---- event detection -------------------------------------------
+        if have_events:
+            new_vals, new_isterm, new_dir, hits = _locate_events_linear(
+                events_fn, t, t_new, y_n, y_new, prev_vals, direction,
+                uround, opt.event_duration)
+            if hits:
+                for (te_i, ye_i, ie_i, term_i) in hits:
+                    nevent += 1
+                    if nevent == te.size:
+                        te = np.concatenate([te, np.zeros(1000)])
+                        ye = np.concatenate([ye, np.zeros((1000, vsize))])
+                        ie = np.concatenate([ie, np.zeros(1000, dtype=int)])
+                    te[nevent] = te_i
+                    ye[nevent] = ye_i
+                    ie[nevent] = ie_i
+                last_te, last_ye, _, last_term = hits[-1]
+                if last_term:
+                    # Land the final reported sample on the event.
+                    nt += 1
+                    if nt >= T.size:
+                        T = np.concatenate([T, np.zeros(1000)])
+                        Y = np.concatenate([Y, np.zeros((1000, vsize))])
+                    T[nt] = last_te
+                    Y[nt] = last_ye
+                    t = last_te
+                    y_n = last_ye
+                    stopped_by_event = True
+                    done = True
+            prev_vals = new_vals
+            direction = new_dir
+            if stopped_by_event:
+                break
+
+        # ---- roll state ------------------------------------------------
+        t = t_new
+        y_n = y_new
+        F_n = F_new
+        f_n = f_diff(F_n)
+
+    if pbar:
+        pbar.close()
+
+    # Trim the unused dense-output tail (the run may have stopped early at
+    # an event or a divergence before filling the whole report grid).
+    T = T[:nt + 1]
+    Y = Y[:nt + 1]
+    if stats.ret != 'failed':
+        stats.succeed = True
+
+    if have_events and nevent >= 0:
+        te = te[:nevent + 1]
+        ye = ye[:nevent + 1]
+        ie = ie[:nevent + 1]
+        return daesol(T, Y, te=te, ye=ye, ie=ie, stats=stats)
+    return daesol(T, Y, stats=stats)
+
+
+def _fail(stats, t, reason):
+    stats.ret = 'failed'
+    stats.succeed = False
+    print(f'PE: integration failed at t = {t:.6g}: {reason}.')
+
+
+def _locate_events_linear(events_fn, t_n, t_new, y_n, y_new, prev_vals,
+                          direction, uround, event_dur):
+    """Locate sign changes of events(t, y) on (t_n, t_new] using a *linear*
+    interpolant y(s) = y_n + s (y_new - y_n), s in [0, 1]. Returns
+    (new_vals, new_isterminal, new_direction, hits) where hits is a
+    time-ordered list of (t_e, y_e, idx, isterminal).
+    """
+    new_vals_raw, new_isterm, new_dir = events_fn(t_new, y_new)
+    new_vals = np.asarray(new_vals_raw, dtype=float)
+    new_isterm = np.asarray(new_isterm)
+    new_dir = np.asarray(new_dir, dtype=float)
+    h = t_new - t_n
+    hits = []
+
+    cross = np.where(prev_vals * new_vals < 0)[0]
+    for i in cross:
+        v0 = prev_vals[i]
+        v1 = new_vals[i]
+        if direction[i] < 0 and v0 <= v1:
+            continue
+        if direction[i] > 0 and v0 >= v1:
+            continue
+        tL, tR = t_n, t_new
+        if abs(v1 - v0) > uround:
+            t_e = t_n - v0 * h / (v1 - v0)
+        else:
+            t_e = t_new
+        tol = max(128.0 * uround, event_dur)
+        y_e = y_n + ((t_e - t_n) / h) * (y_new - y_n)
+        for _it in range(60):
+            s = (t_e - t_n) / h
+            y_e = y_n + s * (y_new - y_n)
+            v_now = np.asarray(events_fn(t_e, y_e)[0], dtype=float)[i]
+            if v1 * v_now < 0:
+                tL = t_e
+                v0 = v_now
+                t_e = 0.5 * (t_e + tR)
+            elif v0 * v_now < 0:
+                tR = t_e
+                v1 = v_now
+                t_e = 0.5 * (tL + t_e)
+            else:
+                break
+            if (tR - tL) < tol:
+                break
+        if t_e - t_n < event_dur:
+            continue
+        hits.append((t_e, y_e, int(i), bool(new_isterm[i])))
+
+    hits.sort(key=lambda r: r[0])
+    return new_vals, new_isterm, new_dir, hits

--- a/Solverz/solvers/test/test_pe_adams_bdf.py
+++ b/Solverz/solvers/test/test_pe_adams_bdf.py
@@ -1,0 +1,142 @@
+import numpy as np
+from scipy.sparse import csc_matrix
+
+from Solverz import AdamsBDF, Opt, PE, Rodas
+
+
+class TinyDAE:
+    def __init__(self, M, F, J):
+        self.M = M
+        self._F = F
+        self._J = J
+        self.p = {}
+
+    def F(self, t, y, p):
+        return self._F(t, y)
+
+    def J(self, t, y, p):
+        return self._J(t, y)
+
+
+def _linear_dae():
+    M = csc_matrix(np.diag([1.0, 0.0]))
+
+    def Fcn(t, y):
+        return np.array([-y[1], y[1] - y[0] ** 2])
+
+    def Jcn(t, y):
+        return csc_matrix(np.array([
+            [0.0, -1.0],
+            [-2.0 * y[0], 1.0],
+        ]))
+
+    return TinyDAE(M, Fcn, Jcn), np.array([1.0, 1.0])
+
+
+def _robertson_dae():
+    M = csc_matrix(np.diag([1.0, 1.0, 0.0]))
+
+    def Fcn(t, y):
+        y1, y2, y3 = y
+        return np.array([
+            -0.04 * y1 + 1.0e4 * y2 * y3,
+            0.04 * y1 - 1.0e4 * y2 * y3 - 3.0e7 * y2 * y2,
+            y1 + y2 + y3 - 1.0,
+        ])
+
+    def Jcn(t, y):
+        y1, y2, y3 = y
+        return csc_matrix(np.array([
+            [-0.04, 1.0e4 * y3, 1.0e4 * y2],
+            [0.04, -1.0e4 * y3 - 6.0e7 * y2, -1.0e4 * y2],
+            [1.0, 1.0, 1.0],
+        ]))
+
+    return TinyDAE(M, Fcn, Jcn), np.array([1.0, 0.0, 0.0])
+
+
+def test_pe_partitioned_accuracy_orders():
+    dae, y0 = _linear_dae()
+    tend = 5.0
+    x_ref = 1.0 / (1.0 + tend)
+    hs = [0.02, 0.01, 0.005]
+
+    for scheme, expected_order, max_error in [
+        ("euler", (0.8, 1.4), 5e-3),
+        ("modified_euler", (1.7, 2.4), 1e-5),
+    ]:
+        errs = []
+        for h in hs:
+            sol = PE(
+                dae,
+                [0.0, tend],
+                y0,
+                Opt(
+                    scheme=scheme,
+                    step_size=h,
+                    ite_tol=1e-12,
+                    rtol=1e-6,
+                    atol=1e-9,
+                ),
+            )
+            errs.append(abs(sol.Y[-1, 0] - x_ref))
+
+        order = np.log(errs[1] / errs[2]) / np.log(hs[1] / hs[2])
+        assert expected_order[0] < order < expected_order[1]
+        assert errs[2] < max_error
+        assert abs(sol.Y[-1, 1] - sol.Y[-1, 0] ** 2) < 1e-8
+
+
+def test_pe_event_and_dense_grid():
+    dae, y0 = _linear_dae()
+
+    def event(t, y):
+        return np.array([y[0] - 0.5]), np.array([1]), np.array([-1])
+
+    sol_event = PE(
+        dae,
+        [0.0, 5.0],
+        y0,
+        Opt(scheme="modified_euler", step_size=0.001, event=event, ite_tol=1e-12),
+    )
+    assert sol_event.te is not None
+    np.testing.assert_allclose(sol_event.te[0], 1.0, atol=1e-3)
+    np.testing.assert_allclose(sol_event.T[-1], sol_event.te[0], atol=1e-9)
+
+    grid = np.linspace(0.0, 5.0, 51)
+    sol_grid = PE(
+        dae,
+        grid,
+        y0,
+        Opt(scheme="modified_euler", step_size=0.001, ite_tol=1e-12),
+    )
+    np.testing.assert_allclose(sol_grid.T, grid, atol=1e-6)
+    np.testing.assert_allclose(sol_grid.Y[:, 0], 1.0 / (1.0 + grid), atol=1e-4)
+
+
+def test_mixed_adams_bdf_linear_dae_and_order_history():
+    dae, y0 = _linear_dae()
+    sol = AdamsBDF(dae, [0.0, 5.0], y0, Opt(rtol=1e-5, atol=1e-8))
+    x_ref = 1.0 / 6.0
+    y_ref = x_ref ** 2
+
+    np.testing.assert_allclose(sol.Y[-1, 0], x_ref, atol=1e-3)
+    np.testing.assert_allclose(sol.Y[-1, 1], y_ref, atol=1e-3)
+    assert sol.stats.order_variation is not None
+    assert sol.stats.order_variation.shape == sol.T.shape
+    assert set(np.unique(sol.stats.order_variation)).issubset({1.0, 2.0})
+
+
+def test_mixed_adams_bdf_robertson_matches_rodas():
+    dae, y0 = _robertson_dae()
+    sol_ref = Rodas(
+        dae,
+        [0.0, 0.4],
+        y0,
+        Opt(rtol=1e-9, atol=1e-12, scheme="rodas3"),
+    )
+    sol = AdamsBDF(dae, [0.0, 0.4], y0, Opt(rtol=1e-5, atol=1e-9))
+
+    err = np.abs(sol.Y[-1] - sol_ref.Y[-1])
+    wt = np.maximum(np.abs(sol_ref.Y[-1]), 1e-6)
+    assert np.max(err / wt) < 0.05

--- a/docs/src/gettingstart.md
+++ b/docs/src/gettingstart.md
@@ -332,6 +332,8 @@ Below is an overview of the built-in solvers.
 2. `implicit_trapezoid()` the [implicit trapezoidal method](https://en.wikipedia.org/wiki/Trapezoidal_rule_(differential_equations)).
 3. `Rodas()` the stiffly accurate Rosenbrock method with adaptive step size, dense output and event detection. One can use it the same as the Ode-series solvers in Matlab. This is the most stable solver in Solverz.
 4. `Radau()` the 3-stage 5th-order Radau IIA fully-implicit Runge-Kutta method, ported from SciML's `RadauIIA5`. Stiffly accurate; recommended for stiff or oscillatory DAEs that need higher order than `Rodas`.
+5. `PE()` the fixed-step partitioned-explicit DAE solver with Euler and modified-Euler differential updates plus an algebraic Newton solve.
+6. `AdamsBDF()` the variable-step mixed Adams-BDF DAE solver, using Adams treatment on differential variables and BDF treatment on algebraic variables.
 
 The detailed usage of these solvers can be found in [api reference](https://docs.solverz.org/reference/index.html).
 

--- a/docs/src/reference/index.rst
+++ b/docs/src/reference/index.rst
@@ -82,4 +82,8 @@ DAE solver
 
 .. autofunction:: Solverz.solvers.daesolver.radau.Radau
 
+.. autofunction:: Solverz.solvers.daesolver.pe.PE
+
+.. autofunction:: Solverz.solvers.daesolver.adams_bdf.AdamsBDF
+
 .. autofunction:: Solverz.solvers.daesolver.ode15s.ode15s

--- a/docs/src/release_notes.md
+++ b/docs/src/release_notes.md
@@ -2,6 +2,12 @@
 
 # Release Notes
 
+## 0.10.3
+
+### New
+
+- **`PE` and `AdamsBDF` are built-in DAE solvers.** `PE` provides fixed-step partitioned-explicit integration with Euler and modified-Euler differential updates followed by an algebraic Newton solve. `AdamsBDF` provides a variable-step mixed Adams-BDF method that applies Adams treatment to differential variables and BDF treatment to algebraic variables. Both solvers are exported from the public `Solverz` namespace and are documented in the DAE solver API reference.
+
 ## 0.10.2
 
 ### Changed


### PR DESCRIPTION
## Summary

Move the partitioned-explicit DAE solver and the mixed Adams-BDF DAE solver from SolAlg into Solverz as built-in DAE solvers.

This PR ports the changes from rzyu45/Solverz-dev#3 for eventual merge into `smallbunnies/solverz:main`.

## What changed

- Added `Solverz.solvers.daesolver.pe.PE` and `Solverz.solvers.daesolver.adams_bdf.AdamsBDF`.
- Exported both solvers through `Solverz.solvers.daesolver`, `Solverz.solvers`, and the public `Solverz` namespace.
- Added pytest coverage for PE accuracy order, PE dense reporting, PE terminal events, Adams-BDF accuracy, Adams-BDF order history, and a Robertson DAE comparison against Rodas.
- Updated the getting-started solver list and API reference.

## Pre-move open-source check

Checked the moved solver code and adapted tests for private paths, credentials, tokens, unpublished-work markers, SolAlg imports, binary/cache artifacts, and obvious license/provenance blockers. No blocking issue was found in the moved files. I did not move SolAlg scratch `_test_*` scripts or `__pycache__` files.

The SolAlg checkout does not include a license file, so this PR keeps the provenance clear by moving only source controlled by the same owner into Solverz and adding fresh Solverz-native tests.

## Validation

```bash
NUMBA_CACHE_DIR=/tmp/numba-cache /opt/miniconda3/envs/sim/bin/python -m pytest Solverz/solvers/test tests/test_dae.py tests/test_rodas_dense.py -vv
```

Result from rzyu45/Solverz-dev#3: 22 passed.