### PR TITLE
fix(loop_jac): resolve composed index maps for Set-backed outer indices

### DIFF
--- a/Solverz/equation/eqn.py
+++ b/Solverz/equation/eqn.py
@@ -1698,7 +1698,8 @@ class _LoopJacBlockCall(Function):
 
 
 class _LoopJacEye(Function):
-    """Sympy ``Function`` node that prints to ``np.eye(n)``.
+    """Sympy ``Function`` node that prints to ``np.eye(n)``, or to
+    ``np.eye(n_outer, n_diff)`` when called with both sizes.
 
     Emitted by :func:`Solverz.equation.loop_jac.loop_jac_to_solverz_expr`
     whenever a LoopEqn derivative simplifies to
@@ -1714,17 +1715,23 @@ class _LoopJacEye(Function):
     a constant-matrix block (zero free symbols), so ``inner_J``
     reduces to ``return _data_`` with the identity baked in at
     module-build time.
+
+    The block is **not** square whenever the LoopEqn's outer range is
+    shorter than the Var it indexes — ``LoopEqn('c', outer_index=
+    Idx('i', 15), body=m.a[i] - 1.0)`` over a 16-entry ``a`` needs a
+    ``15x16`` derivative. Pass both sizes in that case; a single
+    argument keeps the square form.
     """
 
     @classmethod
-    def eval(cls, n):
+    def eval(cls, n, n_diff=None):
         # Don't auto-simplify; we want a Function application that the
         # printer can intercept.
         return None
 
     def _numpycode(self, printer, **kwargs):
-        n_arg = self.args[0]
-        return f'np.eye({printer._print(n_arg)})'
+        sizes = ', '.join(printer._print(a) for a in self.args)
+        return f'np.eye({sizes})'
 
     def _pythoncode(self, printer, **kwargs):
         return self._numpycode(printer, **kwargs)

--- a/Solverz/equation/loop_jac.py
+++ b/Solverz/equation/loop_jac.py
@@ -1741,17 +1741,17 @@ def compute_loop_jac_sparsity(canonical: sp.Expr,
                     r, c = c, r
                 param_hits.append((r, c))
             elif kinds == {'indirect_outer', 'diff'}:
-                # Indirect outer: row is ``map_name[outer]`` for
-                # some known row map. Look up the Param's stored
-                # columns for each ``row = map.v[i]`` and emit
-                # ``(i, col)``.
+                # Indirect outer: the row axis is an index expression
+                # over the outer index, already resolved to concrete
+                # rows. Look up the Param's stored columns for each
+                # ``row = row_map[i]`` and emit ``(i, col)``.
                 if kind0 == 'indirect_outer':
-                    map_name = map0
+                    row_map_ref = map0
                     swapped = False
                 else:
-                    map_name = map1
+                    row_map_ref = map1
                     swapped = True
-                row_map = _map_values(map_name)
+                row_map = _map_values(row_map_ref)
                 val = sol.v
                 n_src_rows = int(val.shape[0])
                 if (row_map.size
@@ -1864,7 +1864,7 @@ def compute_loop_jac_sparsity(canonical: sp.Expr,
             # row.
             col_map = _map_values(col_map_name)
             sparse_param = None
-            sp_row_map_name = None
+            sp_row_map = None
             for sf in sbody_factors:
                 if not isinstance(sf, sp.Indexed):
                     continue
@@ -1885,14 +1885,17 @@ def compute_loop_jac_sparsity(canonical: sp.Expr,
                     continue
                 if kind_row in ('outer', 'indirect_outer'):
                     sparse_param = sobj
-                    sp_row_map_name = map_row  # None for direct
+                    sp_row_map = map_row  # None for direct
                     break
             # Build sparsity entries.
             if sparse_param is not None and hasattr(
                     sparse_param.v, 'tocsr'):
                 csr = sparse_param.v.tocsr()
-                row_map = (_map_values(sp_row_map_name)
-                           if sp_row_map_name else
+                # ``sp_row_map`` is the resolved ndarray for an indirect
+                # row axis and ``None`` for a direct one. Test it
+                # against None: an ndarray has no truth value.
+                row_map = (_map_values(sp_row_map)
+                           if sp_row_map is not None else
                            np.arange(n_outer, dtype=np.int64))
                 for i_outer in range(n_outer):
                     real_row = int(row_map[i_outer])

--- a/Solverz/equation/loop_jac.py
+++ b/Solverz/equation/loop_jac.py
@@ -343,6 +343,99 @@ def loop_jac_to_solverz_expr(expr: sp.Expr,
     )
 
 
+# Recursion cap for :func:`resolve_outer_index_values`. Index maps
+# nest at most two deep in practice (``back[S[g]]``); the cap only
+# guards against a pathological hand-built expression.
+_MAX_INDEX_MAP_DEPTH = 8
+
+
+def resolve_outer_index_values(expr: sp.Expr,
+                                outer_idx: sp.Idx,
+                                n_outer: int,
+                                var_map: Dict[str, object],
+                                _depth: int = 0):
+    """Materialise an integer index expression written over the outer
+    loop index into a concrete ``ndarray`` of length ``n_outer``.
+
+    Returns ``None`` when the expression is not resolvable at build
+    time, so every caller can fall back to its own conservative path.
+
+    Recognised shapes, applied *recursively* so that compositions of
+    any depth resolve:
+
+    * ``outer_idx``                 → ``arange(n_outer)``
+    * ``outer_idx + c``, integer c  → ``arange(n_outer) + c``
+    * ``P[<resolvable>]``           → ``P.v[<resolved>]``, with ``P`` a
+      1-D integer ``Param``
+
+    The last rule is what makes a ``Set``-backed outer index behave
+    like a positional one. ``m.b[m.back[g]]`` with ``g`` produced by
+    ``Set.idx`` desugars to ``b[back[S[g]]]``; the inner ``S[g]``
+    resolves to the set's values and the outer ``back[...]`` gathers
+    through them, giving the same column vector the positional
+    formulation ``m.b[m.map[i]]`` produces directly.
+
+    ``TimeSeriesParam`` is refused: its value is a function of time,
+    so baking the build-time sample into a structural pattern would
+    be wrong the moment the profile moves.
+    """
+    from Solverz.equation.param import ParamBase, TimeSeriesParam
+
+    if _depth > _MAX_INDEX_MAP_DEPTH:
+        return None
+
+    if isinstance(expr, sp.Idx):
+        if _name_of(expr) == _name_of(outer_idx):
+            return np.arange(n_outer, dtype=np.int64)
+        return None
+
+    if isinstance(expr, sp.Indexed):
+        if len(expr.indices) != 1:
+            return None
+        map_obj = var_map.get(expr.base.name)
+        if not isinstance(map_obj, ParamBase):
+            return None
+        if isinstance(map_obj, TimeSeriesParam):
+            return None
+        if getattr(map_obj, 'dim', None) != 1:
+            return None
+        inner_vals = resolve_outer_index_values(
+            expr.indices[0], outer_idx, n_outer, var_map, _depth + 1)
+        if inner_vals is None:
+            return None
+        map_v = np.asarray(map_obj.v).reshape(-1)
+        if not np.issubdtype(map_v.dtype, np.integer):
+            # Accept an integral float array (index Params built via
+            # np.concatenate are routinely upcast to float), reject a
+            # genuinely fractional one.
+            if not np.all(map_v == np.floor(map_v)):
+                return None
+            map_v = map_v.astype(np.int64)
+        if inner_vals.size and (int(inner_vals.min()) < 0
+                                or int(inner_vals.max()) >= map_v.size):
+            return None
+        return map_v[inner_vals].astype(np.int64, copy=False)
+
+    if isinstance(expr, sp.Add):
+        base_vals = None
+        shift = 0
+        for arg in expr.args:
+            if arg.is_Integer:
+                shift += int(arg)
+                continue
+            if base_vals is not None:
+                return None  # two index-bearing addends — not an offset
+            base_vals = resolve_outer_index_values(
+                arg, outer_idx, n_outer, var_map, _depth + 1)
+            if base_vals is None:
+                return None
+        if base_vals is None:
+            return None
+        return base_vals + shift
+
+    return None
+
+
 def _translate_kronecker_delta(
         expr: KroneckerDelta,
         outer_idx: sp.Idx,
@@ -357,15 +450,14 @@ def _translate_kronecker_delta(
 
     Recognized patterns:
 
-    - ``KD(outer, diff)`` → ``_LoopJacEye(n_outer)``
-    - ``KD(diff, map_param[outer])`` → ``_LoopJacSelectMat(...)``
-      where *map_param* is a 1-D integer ``Param`` that maps each
-      outer index to a column.  The result is a sparse selection
-      matrix with one 1 per row.
+    - ``KD(outer, diff)`` → ``_LoopJacEye(n_outer[, n_diff])``
+    - ``KD(diff, <index expression over outer>)`` →
+      ``_LoopJacSelectMat(...)``, where the index expression is
+      anything :func:`resolve_outer_index_values` can materialise —
+      ``map[outer]``, ``back[S[outer]]``, ``outer + c``. The result
+      is a sparse selection matrix with one 1 per row.
     """
-    import numpy as np
     from Solverz.equation.eqn import _LoopJacEye, _LoopJacSelectMat
-    from Solverz.equation.param import ParamBase
 
     outer_name = _name_of(outer_idx)
     diff_name = _name_of(diff_idx)
@@ -375,32 +467,29 @@ def _translate_kronecker_delta(
     # --- direct diagonal: KD(outer, diff) ---
     if ({_name_of(a0), _name_of(a1)}
             == {outer_name, diff_name}):
+        # Rectangular whenever the outer range is shorter than the Var
+        # being differentiated, e.g. a 15-step loop over a 16-entry Var.
+        if n_diff > 0 and n_diff != n_outer:
+            return _LoopJacEye(sp.Integer(n_outer), sp.Integer(n_diff))
         return _LoopJacEye(sp.Integer(n_outer))
 
-    # --- indirect diagonal: KD(diff, map[outer]) ---
+    # --- indirect diagonal: KD(diff, <index expression>) ---
     for arg_d, arg_m in [(a0, a1), (a1, a0)]:
         if not (isinstance(arg_d, sp.Idx)
                 and _name_of(arg_d) == diff_name):
             continue
-        if not isinstance(arg_m, sp.Indexed):
+        col_map = resolve_outer_index_values(
+            arg_m, outer_idx, n_outer, var_map)
+        if col_map is None or col_map.size != n_outer:
             continue
-        if len(arg_m.indices) != 1:
-            continue
-        inner = arg_m.indices[0]
-        if not (isinstance(inner, sp.Idx)
-                and _name_of(inner) == outer_name):
-            continue
-        map_name = arg_m.base.name
-        map_obj = var_map.get(map_name)
-        if not isinstance(map_obj, ParamBase):
-            continue
-        if getattr(map_obj, 'dim', None) != 1:
+        if int(col_map.min()) < 0:
             continue
         # Build the selection matrix node.  Use the caller-supplied
         # n_diff (the actual variable size) when available; fall back
         # to max(col_map)+1 which is a safe lower bound.
-        col_map = np.asarray(map_obj.v, dtype=np.int64).reshape(-1)
-        nd = n_diff if n_diff > 0 else (int(col_map.max()) + 1 if len(col_map) else 0)
+        nd = n_diff if n_diff > 0 else int(col_map.max()) + 1
+        if int(col_map.max()) >= nd:
+            continue
         return _LoopJacSelectMat(
             sp.Tuple(*[sp.Integer(int(c)) for c in col_map]),
             sp.Integer(n_outer),
@@ -711,15 +800,15 @@ def _try_kd_outer_scalars(
     KD shape handling:
 
     * Direct ``KD(outer, diff)`` — emit ``Diag(scalar_vec)``.
-    * Indirect ``KD(diff, map[outer])`` where ``map`` is a 1-D
-      ``ParamBase`` of length ``n_outer`` — emit
-      ``Mat_Mul(Diag(scalar_vec), _LoopJacSelectMat(map, n_outer, n_diff))``.
+    * Indirect ``KD(diff, <index expression over outer>)`` resolving
+      to ``n_outer`` columns via :func:`resolve_outer_index_values` —
+      emit ``Mat_Mul(Diag(scalar_vec), _LoopJacSelectMat(map,
+      n_outer, n_diff))``.
 
     Returns ``None`` on unsupported KD shapes or when the scalar
     product cannot be translated (caller falls back to J3).
     """
     from Solverz.equation.eqn import _LoopJacSelectMat
-    from Solverz.equation.param import ParamBase
     from Solverz.sym_algebra.functions import Diag, Mat_Mul
 
     outer_name = _name_of(outer_idx)
@@ -732,24 +821,14 @@ def _try_kd_outer_scalars(
     if ({_name_of(a0), _name_of(a1)} == {outer_name, diff_name}):
         col_map_v = None
     else:
-        # Indirect: KD(diff, map[outer])
+        # Indirect: KD(diff, <index expression over outer>)
         matched = False
         for arg_d, arg_m in ((a0, a1), (a1, a0)):
             if not (isinstance(arg_d, sp.Idx) and _name_of(arg_d) == diff_name):
                 continue
-            if not isinstance(arg_m, sp.Indexed):
-                continue
-            if len(arg_m.indices) != 1:
-                continue
-            inner = arg_m.indices[0]
-            if not (isinstance(inner, sp.Idx) and _name_of(inner) == outer_name):
-                continue
-            map_name = arg_m.base.name
-            map_obj = var_map.get(map_name)
-            if not (isinstance(map_obj, ParamBase) and map_obj.dim == 1):
-                continue
-            map_v = np.asarray(map_obj.v, dtype=np.int64).reshape(-1)
-            if len(map_v) != n_outer:
+            map_v = resolve_outer_index_values(
+                arg_m, outer_idx, n_outer, var_map)
+            if map_v is None or len(map_v) != n_outer:
                 continue
             if n_diff > 0 and (int(map_v.min()) < 0 or int(map_v.max()) >= n_diff):
                 continue
@@ -1537,14 +1616,16 @@ def compute_loop_jac_sparsity(canonical: sp.Expr,
 
     def _classify_axis(expr):
         """Return ``('outer', None)`` if ``expr`` is the outer Idx,
-        ``('diff', None)`` if ``expr`` is the diff Idx,
-        ``('indirect_outer', map_name)`` if ``expr`` is
-        ``Indexed(map_param, outer_idx)`` where ``map_param`` is a
-        1-D int ``Param``, or ``('outer_shifted', shift)`` if
-        ``expr`` is ``outer_idx + integer_constant`` (e.g.
-        ``off + k + 1``). Otherwise ``(None, None)`` — the axis is
-        not structurally classifiable and the term will fall through
-        to the dense fallback or the numerical probing path.
+        ``('diff', None)`` if ``expr`` is the diff Idx, or
+        ``('indirect_outer', values)`` when ``expr`` is any index
+        expression over the outer index that
+        :func:`resolve_outer_index_values` can materialise —
+        ``map_param[outer]``, ``back[S[outer]]``, ``outer + 1``.
+        ``values`` is the resolved ``ndarray`` of length ``n_outer``.
+
+        Otherwise ``(None, None)`` — the axis is not structurally
+        classifiable and the term will fall through to the dense
+        fallback or the numerical probing path.
         """
         if isinstance(expr, sp.Idx):
             if _name_of(expr) == outer_name:
@@ -1552,46 +1633,20 @@ def compute_loop_jac_sparsity(canonical: sp.Expr,
             if _name_of(expr) == diff_name:
                 return 'diff', None
             return None, None
-        if isinstance(expr, sp.Indexed):
-            if len(expr.indices) != 1:
-                return None, None
-            inner = expr.indices[0]
-            if not isinstance(inner, sp.Idx) or _name_of(inner) != outer_name:
-                return None, None
-            map_name = expr.base.name
-            map_obj = var_map.get(map_name)
-            if not isinstance(map_obj, ParamBase):
-                return None, None
-            if getattr(map_obj, 'dim', None) != 1:
-                return None, None
-            return 'indirect_outer', map_name
-        if isinstance(expr, sp.Add):
-            has_outer = False
-            shift = 0
-            all_simple = True
-            for arg in expr.args:
-                if (isinstance(arg, sp.Idx)
-                        and _name_of(arg) == outer_name):
-                    if has_outer:
-                        all_simple = False
-                        break
-                    has_outer = True
-                elif isinstance(arg, (sp.Integer, sp.Rational,
-                                      sp.Number)):
-                    shift += int(arg)
-                else:
-                    all_simple = False
-                    break
-            if has_outer and all_simple:
-                return 'outer_shifted', shift
+        values = resolve_outer_index_values(
+            expr, outer_idx, n_outer, var_map)
+        if values is not None and values.size == n_outer:
+            return 'indirect_outer', values
         return None, None
 
-    def _map_values(map_name):
+    def _map_values(map_ref):
         """Return the materialised 1-D int array for an indirect
-        outer row map. Assumes the caller has already validated
-        dim=1 and ParamBase via ``_classify_axis``.
+        outer row map — either an already-resolved ``ndarray`` from
+        ``_classify_axis`` or a ``var_map`` Param name.
         """
-        return np.asarray(var_map[map_name].v, dtype=np.int64).reshape(-1)
+        if isinstance(map_ref, np.ndarray):
+            return map_ref
+        return np.asarray(var_map[map_ref].v, dtype=np.int64).reshape(-1)
 
     # Each classified term contributes one or more (row, col)
     # pattern fragments; we accumulate them here and union at
@@ -1616,9 +1671,7 @@ def compute_loop_jac_sparsity(canonical: sp.Expr,
         # ``_sz_loop_dk == row_map.v[i]``.
         has_diag_kron = False
         has_indirect_diag_kron = False
-        indirect_diag_map: str = ''
-        has_shifted_diag_kron = False
-        shifted_diag_shift: int = 0
+        indirect_diag_map = None
         has_probed_kron = False
         probed_kron_entries: list = []
         for f in factors:
@@ -1634,12 +1687,6 @@ def compute_loop_jac_sparsity(canonical: sp.Expr,
                 if kinds == {'indirect_outer', 'diff'}:
                     has_indirect_diag_kron = True
                     indirect_diag_map = map0 if kind0 == 'indirect_outer' else map1
-                    break
-                if 'outer_shifted' in kinds and 'diff' in kinds:
-                    has_shifted_diag_kron = True
-                    shifted_diag_shift = (
-                        map0 if kind0 == 'outer_shifted' else map1
-                    )
                     break
                 diff_side = (0 if kind0 == 'diff'
                              else 1 if kind1 == 'diff'
@@ -1706,6 +1753,14 @@ def compute_loop_jac_sparsity(canonical: sp.Expr,
                     swapped = True
                 row_map = _map_values(map_name)
                 val = sol.v
+                n_src_rows = int(val.shape[0])
+                if (row_map.size
+                        and (int(row_map.min()) < 0
+                             or int(row_map.max()) >= n_src_rows)):
+                    # Row map addresses outside the Param — cannot
+                    # derive a pattern; leave the term unclassified so
+                    # the conservative dense path takes over.
+                    continue
                 if hasattr(val, 'tocsr'):
                     csr = val.tocsr()
                     sub_rows_i = []
@@ -1748,12 +1803,6 @@ def compute_loop_jac_sparsity(canonical: sp.Expr,
             for i_outer, real_col in enumerate(row_map):
                 if 0 <= int(real_col) < n_diff:
                     all_positions.add((int(i_outer), int(real_col)))
-
-        if has_shifted_diag_kron:
-            for i in range(n_outer):
-                col = i + shifted_diag_shift
-                if 0 <= col < n_diff:
-                    all_positions.add((i, col))
 
         if has_probed_kron:
             all_positions.update(probed_kron_entries)
@@ -1867,7 +1916,6 @@ def compute_loop_jac_sparsity(canonical: sp.Expr,
 
         if (not has_diag_kron
                 and not has_indirect_diag_kron
-                and not has_shifted_diag_kron
                 and not has_probed_kron
                 and not param_hits
                 and not has_sum_kd):

--- a/docs/src/release_notes.md
+++ b/docs/src/release_notes.md
@@ -2,6 +2,13 @@
 
 # Release Notes
 
+## 0.10.3
+
+### Fixed
+
+- **A `Set`-backed outer index composed with a second index map forced a dense Jacobian block.** `Set.idx('g')` desugars every access to a gather, so a body written as `m.b[m.back[g]]` reaches the Jacobian pipeline as `b[back[S[g]]]` — two levels of indexing. Both the Phase J1/J2 classifier and the structural sparsity analyzer required the inner index of a map to be a bare `Idx`, so neither recognised the composition and the block fell back to the full `n_outer x n_diff` reservation. The values were always correct, since an over-reservation is a superset of the true pattern, but the cost was paid on every factorization: on a model with 342 coupled rows and 4342 unknowns the assembled Jacobian carried 121 306 nonzeros where 4 684 is exact. A new `resolve_outer_index_values` helper materialises an index expression of any nesting depth into its concrete column vector at build time, so `map[outer]`, `back[S[outer]]`, and `outer + c` all resolve through one rule. The pattern is now the exact permutation, and the same expression also classifies to a constant `_LoopJacSelectMat` instead of falling to the per-entry kernel. Time-varying, fractional, and out-of-range maps are refused rather than guessed, so those cases keep the conservative dense path.
+- **A `LoopEqn` whose outer range was shorter than the `Var` it indexes failed to render.** The identity block of `LoopEqn('c', outer_index=Idx('i', 15), body=m.a[i] - 1.0)` over a 16-entry `a` is `15x16`, but `_LoopJacEye` printed a square `np.eye(n_outer)` unconditionally, so `JacBlock` raised `ValueError: Incompatible matrix derivative size (15, 15) and vector variable size (16,)`. `_LoopJacEye` now takes both sizes and prints `np.eye(n_outer, n_diff)` when they differ.
+
 ## 0.10.2
 
 ### Changed

--- a/tests/test_loop_eqn.py
+++ b/tests/test_loop_eqn.py
@@ -2506,3 +2506,285 @@ def test_index_set_outer_kwarg_matches_outer_index():
         body=m2.x[ii] - m2.target[ii], model=m2,
     )
     assert eqn_via_outer_index.n_outer == eqn_via_outer.n_outer == 2
+
+
+# ---------------------------------------------------------------------
+# Issue #149 — a Set-backed outer index composed with a second index map
+#
+# ``Set.idx('g')`` desugars every access to a gather, so ``m.b[m.back[g]]``
+# reaches the code printer as ``b[back[S[g]]]`` — TWO levels of indexing.
+# The classifier and the sparsity analyzer both used to require the inner
+# index of a map to be a bare ``Idx``, so the block fell back to a dense
+# ``n_outer x n_diff`` reservation even though every index is known at
+# build time. ``resolve_outer_index_values`` now materialises the whole
+# composition, so the pattern is the exact permutation.
+# ---------------------------------------------------------------------
+
+_ISSUE149_ROWS = np.array([0, 2, 3, 5, 7, 9, 11, 13], dtype=int)
+_ISSUE149_NA = 16
+_ISSUE149_N = 8
+
+
+def _issue149_back():
+    back = np.zeros(_ISSUE149_NA, dtype=np.int64)
+    back[_ISSUE149_ROWS] = np.arange(_ISSUE149_N)
+    return back
+
+
+def _issue149_model(body_fn, positional=False):
+    """Build the coupled model in either the ``Set`` + second-map form
+    (the shape issue #149 reports) or the positional form that already
+    produced exact sparsity. ``body_fn(m, outer, col)`` receives the
+    model, the outer index, and the column index expression."""
+    from Solverz import Set
+
+    m = Model()
+    m.a = Var('a', np.arange(_ISSUE149_NA, dtype=float) + 1.0)
+    m.b = Var('b', np.arange(_ISSUE149_N, dtype=float) + 1.0)
+    if positional:
+        m.map = Param('map', _ISSUE149_ROWS, dtype=int)
+        i = Idx('i', _ISSUE149_N)
+        m.c = LoopEqn('c', outer_index=i,
+                      body=body_fn(m, m.map[i], i), model=m)
+    else:
+        m.back = Param('back', _issue149_back(), dtype=int)
+        m.S = Set('S', _ISSUE149_ROWS)
+        g = m.S.idx('g')
+        m.c = LoopEqn('c', outer=m.S, outer_index=g,
+                      body=body_fn(m, g, m.back[g]), model=m)
+    m.pin = Eqn('pin', m.a - 1.0)
+    return m
+
+
+def _fd_jac(F, y, p, h=1e-6):
+    """Central-difference Jacobian. Copies every residual — a rendered
+    ``F`` may reuse one output buffer, in which case ``F(y+h) - F(y-h)``
+    on the raw returns is identically zero."""
+    f0 = np.array(F(y, p), copy=True)
+    J = np.zeros((f0.size, y.size))
+    for j in range(y.size):
+        yp = y.copy(); yp[j] += h
+        ym = y.copy(); ym[j] -= h
+        J[:, j] = (np.array(F(yp, p), copy=True)
+                   - np.array(F(ym, p), copy=True)) / (2 * h)
+    return J
+
+
+def test_issue149_resolve_outer_index_values_composes_maps():
+    """``resolve_outer_index_values`` materialises an index expression
+    of any nesting depth into the concrete column vector."""
+    from Solverz.equation.loop_jac import resolve_outer_index_values
+
+    n = _ISSUE149_N
+    back = _issue149_back()
+    second = (np.arange(n) + 3) % n
+    var_map = {
+        'S': Param('S', _ISSUE149_ROWS, dtype=int),
+        'back': Param('back', back, dtype=int),
+        'back2': Param('back2', second, dtype=int),
+    }
+    g = sp.Idx('g', n)
+    S = sp.IndexedBase('S')
+    back_b = sp.IndexedBase('back')
+    back2_b = sp.IndexedBase('back2')
+
+    def resolve(expr):
+        return resolve_outer_index_values(expr, g, n, var_map)
+
+    np.testing.assert_array_equal(resolve(g), np.arange(n))
+    np.testing.assert_array_equal(resolve(g + 2), np.arange(n) + 2)
+    np.testing.assert_array_equal(resolve(S[g]), _ISSUE149_ROWS)
+    # Two levels — the shape issue #149 reports.
+    np.testing.assert_array_equal(resolve(back_b[S[g]]),
+                                  back[_ISSUE149_ROWS])
+    # Three levels — the recursion is not capped at two.
+    np.testing.assert_array_equal(resolve(back2_b[back_b[S[g]]]),
+                                  second[back[_ISSUE149_ROWS]])
+
+
+def test_issue149_resolve_outer_index_values_refuses_unresolvable():
+    """The resolver returns ``None`` — never a guess — when the map is
+    time-varying, non-integer, addresses out of range, or is rooted at
+    something other than the outer index. Every caller then falls back
+    to its own conservative path."""
+    from Solverz import TimeSeriesParam
+    from Solverz.equation.loop_jac import resolve_outer_index_values
+
+    n = _ISSUE149_N
+    var_map = {
+        'S': Param('S', _ISSUE149_ROWS, dtype=int),
+        'frac': Param('frac', np.arange(n) + 0.5),
+        'short': Param('short', np.arange(3), dtype=int),
+        'ts': TimeSeriesParam('ts', v_series=[0, 1], time_series=[0, 1]),
+    }
+    g = sp.Idx('g', n)
+    other = sp.Idx('other', n)
+    S = sp.IndexedBase('S')
+
+    def resolve(expr):
+        return resolve_outer_index_values(expr, g, n, var_map)
+
+    assert resolve(other) is None                 # not the outer index
+    assert resolve(sp.IndexedBase('frac')[g]) is None
+    assert resolve(sp.IndexedBase('ts')[g]) is None
+    # ``short`` has 3 entries but ``S[g]`` addresses up to 13.
+    assert resolve(sp.IndexedBase('short')[S[g]]) is None
+    assert resolve(sp.IndexedBase('missing')[g]) is None
+
+
+def test_issue149_composed_index_classifies_to_select_mat():
+    """``KD(diff, back[S[g]])`` is a permutation and must translate to a
+    constant ``_LoopJacSelectMat``, not raise ``NotImplementedError``
+    into the dense Phase J3 fallback."""
+    from Solverz.equation.eqn import _LoopJacSelectMat
+    from Solverz.equation.loop_jac import (
+        canonicalize_kronecker, loop_jac_to_solverz_expr,
+    )
+
+    m = _issue149_model(lambda mm, row, col: mm.a[row] - mm.b[col])
+    le = m.c
+    k = sp.Idx('_sz_loop_dk')
+    canonical = canonicalize_kronecker(
+        sp.diff(le.body, sp.IndexedBase('b')[k]), le.outer_index, k)
+    translated = loop_jac_to_solverz_expr(
+        canonical, le.outer_index, k, le.n_outer, le.var_map,
+        n_diff=_ISSUE149_N)
+
+    select = [a for a in sp.preorder_traversal(translated)
+              if isinstance(a, _LoopJacSelectMat)]
+    assert len(select) == 1, f'expected one selection matrix, got {translated}'
+    cols = [int(c) for c in select[0].args[0].args]
+    assert cols == _issue149_back()[_ISSUE149_ROWS].tolist()
+
+
+def test_issue149_composed_index_sparsity_is_the_permutation():
+    """The structural analyzer reserves ``n_outer`` entries, not the
+    full ``n_outer x n_diff`` block, and emits no dense-fallback
+    warning."""
+    import warnings
+
+    from Solverz.equation.loop_jac import (
+        canonicalize_kronecker, compute_loop_jac_sparsity,
+    )
+
+    # A nonlinear coefficient keeps the block on the Phase J3 kernel, so
+    # this exercises the sparsity analyzer rather than the classifier.
+    m = _issue149_model(
+        lambda mm, row, col: mm.a[row] ** 2 - sin(mm.b[col]))
+    le = m.c
+    k = sp.Idx('_sz_loop_dk')
+    canonical = canonicalize_kronecker(
+        sp.diff(le.body, sp.IndexedBase('b')[k]), le.outer_index, k)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter('always')
+        rows, cols = compute_loop_jac_sparsity(
+            canonical, le.outer_index, k, le.var_map,
+            le.n_outer, _ISSUE149_N)
+
+    assert not [w for w in caught if 'dense fallback' in str(w.message)]
+    assert len(rows) == _ISSUE149_N, (
+        f'expected the {_ISSUE149_N}-entry permutation, got {len(rows)} '
+        f'(dense would be {_ISSUE149_N * _ISSUE149_N})'
+    )
+    expected = _issue149_back()[_ISSUE149_ROWS]
+    got = dict(zip(rows.tolist(), cols.tolist()))
+    assert got == {i: int(expected[i]) for i in range(_ISSUE149_N)}
+
+
+def test_issue149_set_plus_map_matches_positional_end_to_end():
+    """The ``Set`` + second-map formulation and the positional one must
+    render to the same Jacobian — same nnz, same values."""
+    def body(mm, row, col):
+        return mm.a[row] - mm.b[col]
+
+    mdl_s, y_s = _mdl_from_module(*_issue149_model(body).create_instance())
+    mdl_p, y_p = _mdl_from_module(
+        *_issue149_model(body, positional=True).create_instance())
+
+    yv = np.asarray(y_s.array, dtype=float)
+    J_s = mdl_s.J(yv, mdl_s.p)
+    J_p = mdl_p.J(np.asarray(y_p.array, dtype=float), mdl_p.p)
+
+    exact = _ISSUE149_NA + 2 * _ISSUE149_N   # pin diagonal + both couplings
+    assert J_s.nnz == J_p.nnz == exact
+    np.testing.assert_allclose(J_s.toarray(), J_p.toarray(), atol=1e-12)
+
+
+def test_issue149_composed_index_jacobian_matches_finite_difference():
+    """Sparsity must be a superset of the true pattern and the stored
+    values must be right — a permutation reservation is only correct if
+    no true nonzero falls outside it."""
+    m = _issue149_model(
+        lambda mm, row, col: mm.a[row] ** 2 - sin(mm.b[col]))
+    mdl, y = _mdl_from_module(*m.create_instance())
+    rng = np.random.default_rng(0)
+    yv = np.asarray(y.array, dtype=float) + 0.1 * rng.standard_normal(
+        len(y.array))
+
+    J = mdl.J(yv, mdl.p)
+    J_fd = _fd_jac(mdl.F, yv, mdl.p)
+    np.testing.assert_allclose(J.toarray(), J_fd, atol=1e-6)
+
+    coo = csc_array(J).tocoo()
+    covered = np.zeros(J.shape, dtype=bool)
+    covered[coo.row, coo.col] = True
+    missing = int(((np.abs(J_fd) > 1e-6) & ~covered).sum())
+    assert missing == 0, f'{missing} true nonzeros outside the pattern'
+
+
+def test_issue149_composed_index_newton_matches_positional():
+    """Both formulations converge to the same solution."""
+    def body(mm, row, col):
+        return mm.a[row] ** 2 - sin(mm.b[col]) - 1.0
+
+    mdl_s, y_s = _mdl_from_module(*_issue149_model(body).create_instance())
+    mdl_p, y_p = _mdl_from_module(
+        *_issue149_model(body, positional=True).create_instance())
+    sol_s = nr_method(mdl_s, y_s)
+    sol_p = nr_method(mdl_p, y_p)
+    np.testing.assert_allclose(np.asarray(sol_s.y.array, dtype=float),
+                               np.asarray(sol_p.y.array, dtype=float),
+                               atol=1e-10)
+
+
+def test_loop_eqn_outer_range_shorter_than_var_renders():
+    """A LoopEqn whose outer range is shorter than the Var it indexes
+    needs a RECTANGULAR identity block. ``_LoopJacEye`` used to emit a
+    square ``np.eye(n_outer)`` unconditionally, so ``JacBlock`` rejected
+    the ``(n-1, n-1)`` value against an ``n``-long variable."""
+    n = 6
+    targets = np.arange(1.0, n + 1)
+
+    m = Model()
+    m.x = Var('x', np.zeros(n))
+    m.target = Param('target', targets)
+    i = Idx('i', n - 1)
+    m.free = LoopEqn('free', outer_index=i,
+                     body=m.x[i] - m.target[i], model=m)
+    m.last = Eqn('last', m.x[n - 1] - targets[n - 1])
+
+    mdl, y = _mdl_from_module(*m.create_instance())
+    sol = nr_method(mdl, y)
+    np.testing.assert_allclose(sol.y['x'], targets, atol=1e-10)
+
+
+def test_loop_eqn_shifted_outer_index_keeps_exact_sparsity():
+    """``m.x[i + 1] - m.x[i]`` over a range one shorter than ``x``. The
+    shifted index used to be a special case in the sparsity analyzer;
+    it now resolves through the same path as an index map, and the
+    pattern must stay the two-band structure rather than widen."""
+    n = 8
+    m = Model()
+    m.x = Var('x', np.zeros(n))
+    i = Idx('i', n - 1)
+    m.diff = LoopEqn('diff', outer_index=i,
+                     body=m.x[i + 1] - m.x[i] - 1.0, model=m)
+    m.anchor = Eqn('anchor', m.x[0])
+
+    mdl, y = _mdl_from_module(*m.create_instance())
+    J = mdl.J(np.asarray(y.array, dtype=float), mdl.p)
+    # (n-1) rows with two entries each, plus the 1-entry anchor row.
+    assert J.nnz == 2 * (n - 1) + 1
+    sol = nr_method(mdl, y)
+    np.testing.assert_allclose(sol.y['x'], np.arange(float(n)), atol=1e-10)

--- a/tests/test_loop_eqn.py
+++ b/tests/test_loop_eqn.py
@@ -2788,3 +2788,58 @@ def test_loop_eqn_shifted_outer_index_keeps_exact_sparsity():
     assert J.nnz == 2 * (n - 1) + 1
     sol = nr_method(mdl, y)
     np.testing.assert_allclose(sol.y['x'], np.arange(float(n)), atol=1e-10)
+
+
+def test_issue149_sum_kd_with_set_backed_row_axis():
+    """A `Set`-backed outer index selecting rows of a sparse 2-D Param
+    inside a `Sum`, with the summed Var reached through a column map.
+
+    This is the incidence-matrix shape network models use, e.g.
+    ``Sum(V_in[NonSlack[i], p] * m[p], p)``. The Sum-KD branch of the
+    sparsity analyzer reads the row axis through ``_classify_axis``,
+    whose payload is now the resolved index array rather than a Param
+    name, so a truth test on it raises
+    ``ValueError: The truth value of an array ... is ambiguous``.
+    Guards the ``is not None`` test that replaced it.
+    """
+    from Solverz import Set
+
+    n_node, n_pipe = 6, 9
+    rng = np.random.default_rng(3)
+    # Each pipe leaves one node and enters another.
+    from_node = rng.integers(0, n_node, n_pipe)
+    to_node = np.array([(f + 1 + rng.integers(0, n_node - 1)) % n_node
+                        for f in from_node])
+    V = np.zeros((n_node, n_pipe))
+    V[from_node, np.arange(n_pipe)] = -1.0
+    V[to_node, np.arange(n_pipe)] = 1.0
+
+    non_slack = np.array([i for i in range(n_node) if i != 0], dtype=int)
+
+    m = Model()
+    m.q = Var('q', np.ones(n_pipe))
+    m.V = Param('V', csc_array(V), dim=2, sparse=True)
+    m.p2n = Param('p2n', to_node.astype(int), dtype=int)   # pipe -> node
+    m.NonSlack = Set('NonSlack', non_slack)
+    i_ns = m.NonSlack.idx('i_ns')
+    p_p = Idx('p_p', n_pipe)
+
+    m.balance = LoopEqn(
+        'balance', outer=m.NonSlack, outer_index=i_ns,
+        body=Sum(m.V[i_ns, p_p] * m.q[m.p2n[p_p]], p_p) - 1.0, model=m)
+    # Square the system: the LoopEqn supplies ``non_slack.size`` rows,
+    # the remaining pipes are pinned.
+    for extra in range(n_pipe - non_slack.size):
+        setattr(m, f'fix{extra}', Eqn(f'fix{extra}', m.q[extra] - 1.0))
+
+    mdl, y = _mdl_from_module(*m.create_instance())
+    yv = np.asarray(y.array, dtype=float)
+    J = mdl.J(yv, mdl.p)
+    J_fd = _fd_jac(mdl.F, yv, mdl.p)
+    np.testing.assert_allclose(J.toarray(), J_fd, atol=1e-6)
+
+    coo = csc_array(J).tocoo()
+    covered = np.zeros(J.shape, dtype=bool)
+    covered[coo.row, coo.col] = True
+    missing = int(((np.abs(J_fd) > 1e-6) & ~covered).sum())
+    assert missing == 0, f'{missing} true nonzeros outside the pattern'


### PR DESCRIPTION
Closes #149.

## Problem

`Set.idx('g')` desugars every access to a gather, so a body written as `m.b[m.back[g]]` reaches the Jacobian pipeline as `b[back[S[g]]]` — **two** levels of indexing. Two places recognise an index map, and both required the inner index to be a bare `Idx`:

- `loop_jac.py:_translate_kronecker_delta` — the classifier. It rejected the composition, so the block fell to the per-entry Phase J3 `LoopEqnDiff` kernel.
- `loop_jac.py:compute_loop_jac_sparsity._classify_axis` — the sparsity analyzer. It also rejected, so that kernel got the full `n_outer x n_diff` dense reservation.

The positional form `m.a[m.map[i]]` stays one level, which is why it already produced exact sparsity.

The values were never wrong — an over-reservation is a superset of the true pattern — but the cost is paid on every factorization. On a model with 342 coupled rows and 4342 unknowns the assembled Jacobian carried **121 306** nonzeros where **4 684** is exact.

## Change

`resolve_outer_index_values` materialises an index expression of any nesting depth into its concrete column vector at build time:

| shape | resolves to |
|---|---|
| `outer` | `arange(n_outer)` |
| `outer + c`, integer `c` | `arange(n_outer) + c` |
| `P[<resolvable>]`, `P` a 1-D integer `Param` | `P.v[<resolved>]` |

One recursive rule replaces the `indirect_outer` and `outer_shifted` special cases in `compute_loop_jac_sparsity`, so the analyzer got shorter. Time-varying, fractional, and out-of-range maps return `None` rather than a guess, so those cases keep the conservative dense path.

The same expression now also classifies to a constant `_LoopJacSelectMat` instead of falling to the per-entry kernel.

### Coupled prerequisite

`_LoopJacEye` printed a square `np.eye(n_outer)` unconditionally, so a `LoopEqn` whose outer range is shorter than the `Var` it indexes raised `ValueError: Incompatible matrix derivative size (15, 15) and vector variable size (16,)`. That failure predates this PR and reproduces identically on `main`, but widening the classifier makes it reachable from more expression shapes, so it is fixed here: `_LoopJacEye` takes both sizes and prints `np.eye(n_outer, n_diff)` when they differ.

## Results

| case | nnz before | nnz after | exact |
|---|---|---|---|
| issue reproducer, `Set` + second map | 88 | **32** | 32 |
| same body, nonlinear coefficient | 88 | **32** | 32 |
| three-level composition `back2[back[S[g]]]` | 88 | **32** | 32 |
| positional control | 32 | 32 | 32 |
| 342 coupled rows / 4342 unknowns | 121 306 | **4 684** | 4 684 |

Every Jacobian was checked entry-by-entry against central differences: max deviation 1.6e-8, and no true nonzero falls outside the stored pattern. Newton on the `Set` form and on the positional form converge to bit-identical solutions.

## Tests

Nine tests added to `tests/test_loop_eqn.py`. Six of them fail on `main` and pass here; the other three are guard rails that pass on both — they assert values and Newton results that a dense over-reservation also satisfies, and that the shifted-index pattern does not widen under the unified resolver.

- `test_issue149_resolve_outer_index_values_composes_maps` — one, two, and three levels of nesting
- `test_issue149_resolve_outer_index_values_refuses_unresolvable` — `TimeSeriesParam`, fractional, out-of-range, foreign index, missing name
- `test_issue149_composed_index_classifies_to_select_mat`
- `test_issue149_composed_index_sparsity_is_the_permutation` — asserts no dense-fallback warning
- `test_issue149_set_plus_map_matches_positional_end_to_end`
- `test_issue149_composed_index_jacobian_matches_finite_difference`
- `test_issue149_composed_index_newton_matches_positional`
- `test_loop_eqn_outer_range_shorter_than_var_renders`
- `test_loop_eqn_shifted_outer_index_keeps_exact_sparsity`

Locally: `pytest tests/ Solverz/` → 218 passed. SolMuseum `main` against this branch → 48 passed.

## What this unlocks

Device data lives per device; network equations are indexed per bus. Reactive droop at generators on a scattered bus subset needs both, so the body reaches generator arrays through the inverse map:

```python
m.GEN = Set('GEN', GENBUS)      # 40 generator buses out of 300
g = m.GEN.idx('g')              # g ranges over BUSES

m.bus = Eqn('bus reactive balance',
            Mat_Mul(m.B, m.Vm) - Mat_Mul(m.Cg, m.Qg) + m.Qd)

m.droop = LoopEqn(
    'gen reactive droop', outer=m.GEN, outer_index=g,
    body=m.Vm[g] - m.Vref[m.b2g[g]] + m.Kq[m.b2g[g]] * m.Qg[m.b2g[g]],
    model=m)
```

On 300 buses and 40 generators: `J nnz` drops from 2878 to 1318, density from 0.0249 to 0.0114, same solution to 1.1e-16. The workaround this replaces is to iterate positions with a plain `Idx` and map position to bus by hand, which puts the bus index on the right-hand side of every access and gives up the `Set` name.

## Not in this PR

`_translate_index_scalar_to_vec` still stops at one gather level, so a nonlinear composed body uses the per-entry kernel rather than `Diag x Select`. Sparsity is already exact there, so that is a speed follow-up, not part of #149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)