### PR TITLE
docs: bring the quoted timings to 0.11.0, and say where the rest come from

### DIFF
--- a/docs/src/gettingstart.md
+++ b/docs/src/gettingstart.md
@@ -307,7 +307,7 @@ industry-standard LLVM compiler library. Numba-compiled numerical algorithms in 
 
 If one wants to take advantage of the dynamic compilation, just set the `jit` arg in `module_printer` to be `True`. 
 Then the models will be compiled at the first time of function evaluation. 
-Though the compilation time of complex models can be of tens of minutes, the compilation results are cached locally. 
+Though the compilation time of complex models can be of several minutes, the largest measured in [#134](https://github.com/smallbunnies/Solverz/issues/134) being about six minutes for a model that renders 1\,230 kernels, the compilation results are cached locally. 
 Hence, the model should be compiled only once. 
 It is recommended to first set `jit=False` to debug the models and then perform dynamic compilation.
 Currently, dynamic compilation is not supported in `made_numerical`.

--- a/docs/src/loopeqn.md
+++ b/docs/src/loopeqn.md
@@ -45,7 +45,9 @@ m.balance = LoopEqn(
 The generated module contains **one** `inner_F<N>` with an explicit
 `for i in range(nb):` inside. One LLVM compilation instead of `nb`.
 On the full 8996-DOF "Big" IES benchmark the cold-cache wall shrinks
-from ≈300 s to ≈150 s — see [#134](https://github.com/smallbunnies/Solverz/issues/134)
+from ≈300 s to ≈150 s, measured in benchmark run 1 of
+[#134](https://github.com/smallbunnies/Solverz/issues/134) and not
+re-measured since — see that issue
 for the measured table.
 
 ## 2. Hello `LoopEqn`
@@ -244,7 +246,12 @@ canonical example of how `LoopEqn` / `LoopOde` scale to a
 production model. On the 8996-DOF Big system, using `loopeqn=True`
 makes the full Rodas run **3.6× faster** than the scalar-`Eqn`
 expansion, measured end-to-end (see the `bench` script alongside the
-test).
+test). That figure is from benchmark run 1 of
+[#134](https://github.com/smallbunnies/Solverz/issues/134) and was not
+re-measured for 0.11.0. Whether `LoopEqn` wins end to end depends on how
+much of the wall time is Jacobian work: on the smaller Cookbook IES,
+whose Rodas run is dominated by residual evaluations, the scalar-`Eqn`
+path is the faster of the two.
 
 ## 7. `LoopOde`: the `LoopEqn` of time derivatives
 
@@ -283,15 +290,17 @@ module_printer(spf, y0, name='my_model',
 
 ## 9. Performance expectations
 
-From `Solverz-Cookbook/docs/source/ae/pf/src/bench_loopeqn_pf.py`
-on case30 (29-bus polar PF, 53 residuals):
+From `Solverz-Cookbook/docs/source/ae/pf/src/bench_pf_loopeqn_vs_polar.py`
+on case30 (30-bus polar PF), measured on Solverz 0.11.0. The Cookbook's
+power-flow chapter quotes the same run, so the two cannot drift apart:
 
 | metric | `loopeqn=False` | `loopeqn=True` | ratio |
 |---|---:|---:|---:|
-| Cold Numba compile | 45 s | 1.2 s | **38× faster** |
-| `@njit` sub-functions | 54 F + 362 J | 4 F + 1 J | **416 → 5** |
-| Hot F eval | 1.11 µs | 2.49 µs | 2.2× slower |
-| Hot J eval | 52.8 µs | 37.2 µs | **1.4× faster** |
+| Cold Numba compile | 49 s | 2.9 s | **17× faster** |
+| `@njit` sub-functions | 416 | 12 | **35× fewer** |
+| Hot F eval | 1.28 µs | 3.73 µs | 2.9× slower |
+| Hot J eval | 41.1 µs | 23.5 µs | **1.8× faster** |
+| Newton-Raphson end to end | 0.29 ms | 0.16 ms | **1.8× faster** |
 
 The warmup wins are structural — you get them for any LoopEqn
 model. The F / J per-call ratios depend on the body shape. Bodies

--- a/docs/src/matrix_calculus.md
+++ b/docs/src/matrix_calculus.md
@@ -709,7 +709,8 @@ intermediate sparse matrices per call, sum them (with explicit-zero
 elimination), and then perform a linear-scan lookup for each output
 position. On a 30-bus power flow case, each `J_(y, p)` call took
 ≈ 280 µs in that pre-0.8 architecture. The scatter-add Numba path
-introduced in 0.8.0 drops that to ≈ 50 µs while producing
+introduced in 0.8.0 dropped that to ≈ 50 µs, and on Solverz 0.11.0 the
+same call takes ≈ 36 µs, while producing
 bit-identical results.
 
 If you want to know whether a particular block in your model is on
@@ -796,6 +797,17 @@ power-flow case does not.
   Cookbook's `bench_pf_matmul_vs_polar.py`; the per-`J_` numbers
   below were captured by importing the rendered DHS module and
   calling `mdl.J(y, mdl.p)` in a tight loop.
+
+```{note}
+The DHS table below is a historical record. It was measured on
+`Solverz==0.8.1` against a `Mat_Mul` formulation of the district-heating
+hydraulics that SolUtil no longer carries: `SolUtil.energyflow.dhs_flow`
+now builds the model from scalar `Eqn`s in a Python loop and contains no
+`Mat_Mul` call, so neither `Mat_Mul` row can be reproduced from it. The
+ratios still illustrate the point of this chapter, but do not read them as
+current figures. See the Cookbook's power-flow chapter for a `Mat_Mul`
+comparison measured on the current release.
+```
 
 **DHS hydraulic subproblem on `BarryIsland`** (35 unknowns, 1 loop,
 1 mutable-matrix block — the loop pressure Jacobian contains two


### PR DESCRIPTION
Three documents quoted wall-clock figures with no version attached, and two of them disagreed with the Cookbook about the same measurement.

**`loopeqn.md` disagreed with the Cookbook.** It gave the case30 comparison as "416 → 5 kernels" and a 38× cold compile, where the Cookbook's power-flow chapter gave 416 → 12 and 17× for nominally the same thing. They came from two different scripts. The table is now the same run the Cookbook quotes, measured on 0.11.0, and names that script, so the two cannot drift apart again.

**The 8996-DOF Big IES figures are not re-measured**, because this release did not set up a driver for that model. They now say so and point at benchmark run 1 of #134. The claim that `LoopEqn` makes the Rodas run 3.6 times faster is qualified as well: on the smaller Cookbook IES, whose Rodas run is dominated by residual evaluations rather than Jacobian work, the scalar-`Eqn` path is now the faster of the two, and a reader should know which way the trade goes before choosing. Measured both ways in [benchmark run 2](https://github.com/smallbunnies/Solverz/issues/134#issuecomment-5623291861).

**`matrix_calculus.md`** gave a per-`J` call cost as though it were current; it is now given for 0.11.0 alongside the historical value. Its DHS table cannot be re-measured at all: `SolUtil.energyflow.dhs_flow` now contains no `Mat_Mul` call and builds the model from scalar `Eqn`s in a loop, so neither `Mat_Mul` row has a formulation left to measure. The table is marked as the historical record it is rather than left to read as current.

**`gettingstart.md`** said compilation "can be of tens of minutes". The largest measured in #134 is about six minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3EK7oJ8LrP2F4Ykr4zTS9