### PR TITLE
fix(loop_jac): raise instead of warn when a canonical Jacobian is unsound

### DIFF
--- a/Solverz/equation/eqn.py
+++ b/Solverz/equation/eqn.py
@@ -1650,6 +1650,7 @@ class LoopEqn(Eqn):
         """
         from Solverz.variable.ssymbol import Var
         from Solverz.equation.loop_jac import (
+            UnsoundLoopJacobianError,
             canonicalize_kronecker,
             loop_jac_to_solverz_expr,
         )
@@ -1671,9 +1672,16 @@ class LoopEqn(Eqn):
             if is_zero(raw_deriv):
                 continue
 
-            canonical = canonicalize_kronecker(
-                raw_deriv, self.outer_index, k
-            )
+            try:
+                canonical = canonicalize_kronecker(
+                    raw_deriv, self.outer_index, k
+                )
+            except UnsoundLoopJacobianError as err:
+                # The check runs deep inside the canonicalization, where
+                # the equation and the variable are unknown. Name them.
+                raise UnsoundLoopJacobianError(
+                    err.problems, err.canonical,
+                    f'{self.name} w.r.t. {var_iVar.name}') from None
             if is_zero(canonical):
                 continue
 

--- a/Solverz/equation/loop_jac.py
+++ b/Solverz/equation/loop_jac.py
@@ -84,11 +84,42 @@ def _references_index(expr, idx) -> bool:
                for sym in expr.free_symbols)
 
 
-def check_canonical_invariants(canonical: sp.Expr,
-                                eqn_name: str = '',
-                                var_name: str = '') -> List[str]:
-    """Report two states of a canonical Jacobian expression that mean a
-    defect upstream. They differ in severity, and the messages say so.
+class UnsoundLoopJacobianError(RuntimeError):
+    """A canonical ``LoopEqn`` Jacobian is in a state that
+    :func:`canonical_problems` reports. ``problems`` lists the states and
+    ``canonical`` is the expression that carries them.
+
+    It derives from ``RuntimeError`` because both states are defects
+    inside Solverz, not bad input, so an ``except ValueError`` written for
+    bad input does not swallow it (issue #177).
+    """
+
+    def __init__(self, problems: List[str], canonical: sp.Expr, where: str = ''):
+        self.problems = list(problems)
+        self.canonical = canonical
+        # Only the escaped dummy makes the Jacobian wrong. Say which this
+        # is, so an error about the milder state does not claim that the
+        # result would have been wrong.
+        wrong = any('outside every Sum' in x for x in self.problems)
+        severity = (
+            "The generated Jacobian would be wrong, not merely over-reserved."
+            if wrong else
+            "The Jacobian would be assembled by label, which is correct only "
+            "if the indices sharing a label denote the same thing, and that "
+            "is not checked here."
+        )
+        super().__init__(
+            "LoopEqn canonical Jacobian is structurally unsound"
+            + (f" for {where}" if where else "")
+            + f". {severity} "
+            + "; ".join(self.problems)
+            + f". Canonical: {canonical}")
+
+
+def canonical_problems(canonical: sp.Expr) -> List[str]:
+    """Describe the states of a canonical Jacobian expression that mean a
+    defect upstream, or return an empty list when the expression is sound.
+    :func:`check_canonical_invariants` raises on any of them.
 
     1. **Two free symbols share a printed name.** Every structural test
        in this module compares indices by label, so it reads the two as
@@ -105,11 +136,6 @@ def check_canonical_invariants(canonical: sp.Expr,
        and the generated kernel then reads whatever value the loop
        variable last held. This one does make the Jacobian wrong, and
        finitely so, which is why nothing downstream notices.
-
-    Returns the list of problem descriptions, empty when the expression
-    is sound. Callers warn rather than raise, so a model that hits
-    either still runs and can be checked against a finite-difference
-    Jacobian.
     """
     problems: List[str] = []
 
@@ -147,26 +173,27 @@ def check_canonical_invariants(canonical: sp.Expr,
                         f"was lifted out of "
                         f"Sum(..., {tuple(node.limits[0])})")
 
+    return problems
+
+
+def check_canonical_invariants(canonical: sp.Expr,
+                                eqn_name: str = '',
+                                var_name: str = '') -> List[str]:
+    """Raise :class:`UnsoundLoopJacobianError` when
+    :func:`canonical_problems` finds either state, and return the empty
+    list otherwise.
+
+    It warned until 0.11.1, so that a model in either state still ran and
+    could be compared with a finite-difference Jacobian. Either state was
+    reachable then, because one model's symbols could reach another's
+    (issues #168 and #175). With both fixed nothing reaches it, and a
+    model that does now fails where the defect is instead of running on a
+    wrong Jacobian (issue #177).
+    """
+    problems = canonical_problems(canonical)
     if problems:
         where = ' '.join(x for x in (eqn_name, var_name) if x)
-        # Only the escaped dummy makes the Jacobian wrong. Say which
-        # this is, so a warning about the milder state does not read as
-        # an alarm about a result that is in fact correct.
-        wrong = any('outside every Sum' in x for x in problems)
-        severity = (
-            "The generated Jacobian is wrong, not merely over-reserved."
-            if wrong else
-            "The Jacobian is still assembled by label, so it is correct as "
-            "long as the indices sharing a label denote the same thing, "
-            "which is not checked here."
-        )
-        warnings.warn(
-            "LoopEqn canonical Jacobian is structurally unsound"
-            + (f" for {where}" if where else "")
-            + f". {severity} "
-            + "; ".join(problems)
-            + f". Canonical: {canonical}",
-            stacklevel=3)
+        raise UnsoundLoopJacobianError(problems, canonical, where)
     return problems
 
 

--- a/docs/src/release_notes.md
+++ b/docs/src/release_notes.md
@@ -2,6 +2,12 @@
 
 # Release Notes
 
+## 0.11.2
+
+### Changed
+
+- **A `LoopEqn` whose canonical Jacobian is structurally unsound now fails to build instead of warning.** `check_canonical_invariants` reports two states of a canonical `LoopEqn` Jacobian that always mean a defect upstream. One is two free symbols that share a printed name, which the analyzer, since it compares indices by label, reads as one index. The other is a `Sum` dummy that also occurs outside every `Sum`, which makes the generated Jacobian wrong. The check warned, so that a model in either state still ran and could be compared with a finite-difference Jacobian, and Newton or Rodas then ran on a Jacobian that could be wrong. Both states were reachable while one model's symbols could reach another's, and the fixes of [#168](https://github.com/smallbunnies/Solverz/issues/168) and [#175](https://github.com/smallbunnies/Solverz/issues/175) in 0.11.1 closed that path. Nothing in Solverz, SolMuseum or the Cookbook reaches either state, and their test suites pass with the warning turned into an error. The check now raises `UnsoundLoopJacobianError`, a `RuntimeError`, from `create_instance`, and the message names the equation and the variable. `canonical_problems` returns the same descriptions without raising. See [#177](https://github.com/smallbunnies/Solverz/issues/177).
+
 ## 0.11.1
 
 ### Fixed

--- a/tests/test_indexed_symbol_identity.py
+++ b/tests/test_indexed_symbol_identity.py
@@ -6,9 +6,8 @@ does not print, namely the token of a ``Set`` index and the bounds of an
 share one cached instance. SymPy's caches, keyed on that equality, then handed
 a later model an expression that held an earlier model's index.
 """
-import warnings
-
 import numpy as np
+import pytest
 import sympy as sp
 from scipy.sparse import csc_array
 
@@ -61,6 +60,9 @@ def test_equality_follows_the_base_symbol():
     assert Para('A', dim=2)[0, 1] == Para('A', dim=2)[0, 1]
 
 
+# The ring has one equation per PQ bus and two variables per bus, which
+# create_instance reports; the size is not what this test checks.
+@pytest.mark.filterwarnings('ignore:Equation size')
 def test_loop_eqn_jacobian_after_a_symbol_cache_eviction():
     """The cookbook shape: two power-flow-shaped builds in one process, with
     enough symbols created in between to evict the first build's indexed
@@ -71,7 +73,7 @@ def test_loop_eqn_jacobian_after_a_symbol_cache_eviction():
         ring[k, (k + 1) % n] = ring[(k + 1) % n, k] = 1.0
         ring[k, k] = -2.0
 
-    def unsound_after_build():
+    def build():
         m = Model()
         m.Vm = Var('Vm', np.ones(n))
         m.Va = Var('Va', np.linspace(0.0, 0.2, n))
@@ -82,13 +84,11 @@ def test_loop_eqn_jacobian_after_a_symbol_cache_eviction():
         j = m.Bus.idx('j')
         body = m.Vm[i_q] * Sum(m.Vm[j] * m.Bbus[i_q, j] * sin(m.Va[i_q] - m.Va[j]), j)
         m.Q_eqn = LoopEqn('Q_eqn', outer_index=i_q, body=body, model=m)
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter('always')
-            spf, y0 = m.create_instance()
-            spf.FormJac(y0)
-        return [str(w.message) for w in caught if 'structurally unsound' in str(w.message)]
+        # An unsound canonical Jacobian raises inside (issue #177).
+        spf, y0 = m.create_instance()
+        spf.FormJac(y0)
 
-    assert unsound_after_build() == []
+    build()
     for k in range((sp.core.cache.SYMPY_CACHE_SIZE or 0) + 100):
         sp.Symbol(f'_sz_evict_{k}')
-    assert unsound_after_build() == []
+    build()

--- a/tests/test_loop_eqn.py
+++ b/tests/test_loop_eqn.py
@@ -2932,15 +2932,13 @@ def test_issue151_plain_idx_shorter_than_param_rows_linear_body():
 def _assert_canonical_sane(name, canonical):
     """Delegate to the production invariant check so the test and the
     library can never drift apart. See
-    ``Solverz.equation.loop_jac.check_canonical_invariants`` for what the
-    two invariants are and why violating either yields a Jacobian that is
+    ``Solverz.equation.loop_jac.canonical_problems`` for what the two
+    invariants are and why violating either yields a Jacobian that is
     wrong rather than merely over-reserved.
     """
-    from Solverz.equation.loop_jac import check_canonical_invariants
+    from Solverz.equation.loop_jac import canonical_problems
 
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore')
-        problems = check_canonical_invariants(canonical)
+    problems = canonical_problems(canonical)
     assert not problems, f"{name}: " + "; ".join(problems)
 
 
@@ -3145,8 +3143,7 @@ def test_loop_eqn_polar_pf_survives_a_mismatched_sum_dummy_object():
         warnings.simplefilter('always')
         spf, y0 = m.create_instance()
     bad = [str(w.message) for w in caught
-           if 'dense fallback' in str(w.message)
-           or 'structurally unsound' in str(w.message)]
+           if 'dense fallback' in str(w.message)]
     assert not bad, " | ".join(bad)
 
     for eqn_name in ('P_eqn', 'Q_eqn'):
@@ -3183,9 +3180,10 @@ def test_loop_eqn_polar_pf_survives_a_mismatched_sum_dummy_object():
     np.testing.assert_allclose(sol.y['Va'], Va_t, atol=1e-8)
 
 
-def test_check_canonical_invariants_reports_a_lifted_delta():
-    """The guard must speak on the two states it exists for, and stay
-    silent on the shapes a sound canonicalisation legitimately produces.
+def test_check_canonical_invariants_raises_on_a_lifted_delta():
+    """The guard must stop the build on the two states it exists for, and
+    stay silent on the shapes a sound canonicalisation legitimately
+    produces (issue #177).
 
     A ``KroneckerDelta`` naming a ``Sum``'s dummy from OUTSIDE that
     ``Sum`` is the shape the cookbook CI produced. It is not a slow
@@ -3194,9 +3192,12 @@ def test_check_canonical_invariants_reports_a_lifted_delta():
     index rather than the dummy is the legitimate pulled-out form and
     must not be reported.
     """
+    import pytest
     from sympy.functions.special.tensor_functions import KroneckerDelta
 
-    from Solverz.equation.loop_jac import check_canonical_invariants
+    from Solverz.equation.loop_jac import (UnsoundLoopJacobianError,
+                                           canonical_problems,
+                                           check_canonical_invariants)
 
     k = sp.Idx('_sz_loop_dk')
     i = sp.Idx('i', 6)
@@ -3204,15 +3205,16 @@ def test_check_canonical_invariants_reports_a_lifted_delta():
     f = sp.IndexedBase('f')
 
     sound = KroneckerDelta(k, i) * sp.Sum(f[j], (j, 0, 5))
+    assert canonical_problems(sound) == []
     assert check_canonical_invariants(sound) == []
 
     lifted = KroneckerDelta(k, j) * sp.Sum(f[j], (j, 0, 5))
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter('always')
-        problems = check_canonical_invariants(lifted, 'eqn', 'x')
-    assert len(problems) == 1
-    assert 'occurs outside every Sum' in problems[0]
-    assert any('structurally unsound' in str(w.message) for w in caught)
+    with pytest.raises(UnsoundLoopJacobianError,
+                       match='structurally unsound for eqn x') as info:
+        check_canonical_invariants(lifted, 'eqn', 'x')
+    assert len(info.value.problems) == 1
+    assert 'occurs outside every Sum' in info.value.problems[0]
+    assert 'would be wrong' in str(info.value)
 
     # Two objects of one label. Built the way Set.idx makes reachable:
     # a SetIdx and a plain Idx of the same name and bounds.
@@ -3220,9 +3222,7 @@ def test_check_canonical_invariants_reports_a_lifted_delta():
 
     j_set = IndexSet('S', 6).idx('j')
     twins = f[j_set] + f[j]
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore')
-        problems = check_canonical_invariants(twins)
+    problems = canonical_problems(twins)
     # The twin index and every Indexed built on it are both reported,
     # which is the pattern the cookbook CI showed: i_p twice and
     # PVPQ[i_p] twice in one expression.
@@ -3230,6 +3230,8 @@ def test_check_canonical_invariants_reports_a_lifted_delta():
     assert len(idx_problem) == 1
     assert 'SetIdx' in idx_problem[0] and 'Idx(' in idx_problem[0]
     assert any(x.startswith("index label 'f[j]'") for x in problems)
+    with pytest.raises(UnsoundLoopJacobianError, match='assembled by label'):
+        check_canonical_invariants(twins)
 
 
 def _sin_walker_module(tmp_path, name, G):

--- a/tests/test_unsound_loop_jacobian.py
+++ b/tests/test_unsound_loop_jacobian.py
@@ -1,0 +1,56 @@
+"""A structurally unsound canonical LoopEqn Jacobian fails the build (issue #177).
+
+``check_canonical_invariants`` used to warn, so a model whose canonical
+Jacobian carried an escaped ``Sum`` dummy still built and ran on a wrong
+Jacobian. It now raises ``UnsoundLoopJacobianError``, and
+``LoopEqn.derive_derivative`` names the equation and the variable.
+"""
+import numpy as np
+import pytest
+from scipy.sparse import csc_array
+
+import Solverz.equation.loop_jac as loop_jac
+from Solverz import LoopEqn, Model, Param, Set, Sum, Var, sin
+from Solverz.equation.loop_jac import UnsoundLoopJacobianError
+
+# The ring has one equation per PQ bus and two variables per bus, which
+# create_instance reports; the size is not what these tests check.
+pytestmark = pytest.mark.filterwarnings('ignore:Equation size')
+
+
+def _ring_model(n=9):
+    ring = np.zeros((n, n))
+    for k in range(n):
+        ring[k, (k + 1) % n] = ring[(k + 1) % n, k] = 1.0
+        ring[k, k] = -2.0
+    m = Model()
+    m.Vm = Var('Vm', np.ones(n))
+    m.Va = Var('Va', np.linspace(0.0, 0.2, n))
+    m.Bbus = Param('Bbus', csc_array(ring), dim=2, sparse=True)
+    m.Bus = Set('Bus', n)
+    m.PQ = Set('PQ', np.array([3, 4, 5, 6, 7, 8]))
+    i_q = m.PQ.idx('i_q')
+    j = m.Bus.idx('j')
+    body = m.Vm[i_q] * Sum(m.Vm[j] * m.Bbus[i_q, j] * sin(m.Va[i_q] - m.Va[j]), j)
+    m.Q_eqn = LoopEqn('Q_eqn', outer_index=i_q, body=body, model=m)
+    return m
+
+
+def test_an_escaped_sum_dummy_fails_create_instance(monkeypatch):
+    """Switching off both label comparisons of a ``KroneckerDelta`` with
+    the ``Sum`` dummy, the match and the test for a reference, reproduces
+    the cookbook CI failure fixed in #163. Both used SymPy equality then,
+    and a ``SetIdx`` met a plain ``Idx`` of the same label. The delta on
+    the dummy is then lifted out of its ``Sum``, and the build must stop.
+    With the match alone switched off, the delta stays inside its ``Sum``
+    as a reference to the dummy, and the canonical form is sound."""
+    monkeypatch.setattr(loop_jac, '_index_matches', lambda expr, idx: False)
+    monkeypatch.setattr(loop_jac, '_references_index', lambda expr, idx: False)
+    with pytest.raises(UnsoundLoopJacobianError, match=r'for Q_eqn w\.r\.t\. V') as info:
+        _ring_model().create_instance()
+    assert any('outside every Sum' in p for p in info.value.problems)
+
+
+def test_a_sound_model_builds_without_error():
+    spf, y0 = _ring_model().create_instance()
+    spf.FormJac(y0)


### PR DESCRIPTION
Closes #177. Based on `main` after the 0.11.1 merges; the release note opens a 0.11.2 section.

## What changes

- `check_canonical_invariants` raises `UnsoundLoopJacobianError`, a `RuntimeError`, where it warned. The message is the one the warning carried, and it names the equation and the variable.
- The detection is now `canonical_problems`, which returns the descriptions without raising.
- `LoopEqn.derive_derivative` catches the error and raises it again with the equation and the variable. The check runs inside `canonicalize_kronecker`, on every `Sum` body it recurses into as well, where neither is known. Only there does it see a delta lifted out of an inner `Sum` that is still inside an outer one.

## Why

Both states always mean a defect upstream. The escaped `Sum` dummy makes the generated Jacobian wrong, and finitely so, so Newton or Rodas runs on it without a NaN to notice. The shared label makes the analyzer read two indices as one, and a gather goes through the wrong set when the two sets differ. A warning let models in either state still run while #168 and #175 made the states reachable. Both are fixed in 0.11.1, and nothing in Solverz, SolMuseum or the cookbook reaches either state.

The error derives from `RuntimeError` rather than `ValueError`, because both states are defects inside Solverz, not bad input, and an `except ValueError` written for bad input should not swallow them.

## Tests and checks

- `tests/test_unsound_loop_jacobian.py` reproduces the cookbook CI failure of #163 by switching off both label comparisons of a delta with the `Sum` dummy, and expects `create_instance` to fail with `Q_eqn` and the variable named. With the match alone switched off the delta stays inside its `Sum` and the model builds, as the docstring records.
- The tests that expected the warning now expect the error or call `canonical_problems`. On the parent commit the new file fails at its import, and the rewritten invariant test fails.
- Solverz suite: 267 passed in the collection order of CI and with `tests/` first, with the warnings of `main`.
- SolMuseum, 48 passed, and the cookbook, 18 passed under four xdist workers, against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SvpcpunCpqKyMwzp1LDjf4
